### PR TITLE
Redis::CommandError (ERR value is not an integer or out of range):

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ A [Rack::Request](http://rack.rubyforge.org/doc/classes/Rack/Request.html) objec
 
 ### Throttles
 
-*NOTE:* If you are using Redis as backing store, Redis-ActiveSupport does not recognize `1.second` so just specify the `:period` parameter in seconds.
-    
     # Throttle requests to 5 requests per second per ip
     Rack::Attack.throttle('req/ip', :limit => 5, :period => 1.second) do |req|
       # If the return value is truthy, the cache key for the return value

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -9,7 +9,7 @@ module Rack
           raise ArgumentError.new("Must pass #{opt.inspect} option") unless options[opt]
         end
         @limit  = options[:limit]
-        @period = options[:period]
+        @period = options[:period].to_i
       end
 
       def cache


### PR DESCRIPTION
If users are using Redis and getting the error message `Redis::CommandError (ERR value is not an integer or out of range):` they need to make sure to set the `:period` parameter in throttle as an integer and not a Ruby time unit (`1.second` or `1.minute`).

Added note in README to help users who choose Redis as their backing store not get stuck by this gotcha.
