### PR TITLE
Explain why README examples use 503 to distract attackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Customize the response of blacklisted and throttled requests using an object tha
 ```ruby
     Rack::Attack.blacklisted_response = lambda do |env|
       # Using 503 because it may make attacker think that they have successfully
-      # DOSed the site, Rack::Attack returns 401 for blacklists by default
+      # DOSed the site. Rack::Attack returns 401 for blacklists by default
       [ 503, {}, ['Blocked']]
     end
 
@@ -179,7 +179,7 @@ Customize the response of blacklisted and throttled requests using an object tha
       ].inspect
 
       # Using 503 because it may make attacker think that they have successfully
-      # DOSed the site, Rack::Attack returns 401 for blacklists by default
+      # DOSed the site. Rack::Attack returns 429 for throttling by default
       [ 503, {}, [body]]
     end
 ```


### PR DESCRIPTION
This is a follow-up to pull request #20 for adding documentation to the README
