### PR TITLE
Updated README about minimum version for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Rack::Attack is a rack middleware to protect your web app from bad clients.
 It allows *whitelisting*, *blacklisting*, *throttling*, and *tracking* based on arbitrary properties of the request.
 
-Throttle state is stored in a configurable cache (e.g. `Rails.cache`), presumably backed by memcached or redis.
+Throttle state is stored in a configurable cache (e.g. `Rails.cache`), presumably backed by memcached or redis (at least v3.0.0).
 
 ## Installation
 


### PR DESCRIPTION
Any version before redis 3.0.0, the pipeline method doesn't allow you to reference the future value of results. So the count will never increment, if you use an older redis version.
