### PR TITLE
Update deprecated nginx limit_zone to limit_conn_zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ so try to keep the number of throttle checks per request low.
 If a request is blacklisted or throttled, the response is a very simple Rack response.
 A single typical ruby web server thread can block several hundred requests per second.
 
-Rack::Attack complements tools like `iptables` and nginx's [limit_zone module](http://wiki.nginx.org/HttpLimitZoneModule).
+Rack::Attack complements tools like `iptables` and nginx's [limit_conn_zone module](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone).
 
 ## Motivation
 


### PR DESCRIPTION
Old link (http://wiki.nginx.org/HttpLimitZoneModule) says:

> WARNING: this article is obsoleted. Please refer to http://nginx.org/en/docs/ for the latest official documentation.

New docs for limit_zone (http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_zone) say:

> This directive is made obsolete in version 1.1.8, an equivalent limit_conn_zone directive with a changed syntax should be used instead

This updates the link to go to limit_conn_zone docs instead.
