### PR TITLE
If redis client throws exception, don't raise it

### DIFF
--- a/lib/rack/attack/store_proxy.rb
+++ b/lib/rack/attack/store_proxy.rb
@@ -26,6 +26,8 @@ module Rack
 
         def read(key)
           self.get(key)
+          rescue Redis::BaseError
+            nil
         end
 
         def write(key, value, options={})
@@ -34,6 +36,8 @@ module Rack
           else
             self.set(key, value)
           end
+          rescue Redis::BaseError
+            nil
         end
 
         def increment(key, amount, options={})
@@ -43,6 +47,8 @@ module Rack
             self.expire(key, options[:expires_in]) if options[:expires_in]
           end
           count.value if count
+          rescue Redis::BaseError
+            nil
         end
 
       end

--- a/spec/rack_attack_cache_spec.rb
+++ b/spec/rack_attack_cache_spec.rb
@@ -78,6 +78,34 @@ if ENV['TEST_INTEGRATION']
 
     end
 
+    describe "should not error if redis is not running" do
+      before {
+        @cache = Rack::Attack::Cache.new
+        @key = "rack::attack:cache-test-key"
+        @expires_in = 1
+        # Use ip reserved for documentation to ensure it does not exist
+        # http://tools.ietf.org/html/rfc5737
+        @cache.store = ActiveSupport::Cache::RedisStore.new(:host => '203.0.113.0', :port => 3333)
+      }
+      describe "write" do
+        it "should not raise exception" do
+          @cache.write("cache-test-key", "foobar", 1)
+        end
+      end
+
+      describe "read" do
+        it "should not raise exception" do
+          @cache.read("cache-test-key")
+        end
+      end
+
+      describe "do_count" do
+        it "should not raise exception" do
+          @cache.send(:do_count, @key, @expires_in)
+        end
+      end
+    end
+
   end
 else
   puts 'Skipping cache store integration tests (set ENV["TEST_INTEGRATION"] to enable)'


### PR DESCRIPTION
For throttling, when the redis client throws an exception, the request
ends up getting rate limited. Modify this to be similar to how
ActiveSupport.MemCacheStore functions (the read, write and increment
methods do not raise exceptions)
