### PR TITLE
Support older dalli client versions

### DIFF
--- a/lib/rack/attack/store_proxy.rb
+++ b/lib/rack/attack/store_proxy.rb
@@ -58,6 +58,7 @@ module Rack
       class DalliProxy < SimpleDelegator
         def initialize(client)
           super(client)
+          stub_with_method_on_older_clients
         end
 
         def read(key)
@@ -79,6 +80,15 @@ module Rack
             client.incr(key, amount, options.fetch(:expires_in, 0), amount)
           end
         rescue Dalli::DalliError
+        end
+
+        private
+
+        # So we support Dalli < 2.7.0
+        def stub_with_method_on_older_clients
+          unless __getobj__.respond_to?(:with)
+            def __getobj__.with; yield self; end
+          end
         end
 
       end

--- a/spec/integration/rack_attack_cache_spec.rb
+++ b/spec/integration/rack_attack_cache_spec.rb
@@ -141,4 +141,11 @@ describe Rack::Attack::Cache do
     end
   end
 
+  describe "given an older Dalli::Client" do
+    it "should stub #with" do
+      proxy = Rack::Attack::StoreProxy::DalliProxy.new(Class.new)
+      proxy.must_respond_to :with
+    end
+  end
+
 end


### PR DESCRIPTION
@ktheory I have not actually tried this with an actual older client but I'm presuming it will work. Skimming over the API of 1.1.5, everything looks OK apart from the absence of #with. 

CC: #55
