### PR TITLE
Added new meter functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ def call(env)
     blacklisted_response[env]
   elsif throttled?(req)
     throttled_response[env]
+  elsif metered?(req)
+    @app.call(env)
   else
     tracked?(req)
     @app.call(env)
@@ -87,9 +89,14 @@ end
 
 `Rack::Attack.track` doesn't affect request processing. Tracks are an easy way to log and measure requests matching arbitrary attributes.
 
+## About Meters
+
+`Rack::Attack.meter` doesn't affect request processing otherwise they work like throttles. Meters are an easy way to log and measure
+production requests matching potential throttle limits to determine if they are appropriate before the throttle is enabled.
+
 ## Usage
 
-Define whitelists, blacklists, throttles, and tracks as blocks that return truthy values if matched, falsy otherwise. In a Rails app
+Define whitelists, blacklists, throttles, meters and tracks as blocks that return truthy values if matched, falsy otherwise. In a Rails app
 these go in an initializer in `config/initializers/`.
 A [Rack::Request](http://rack.rubyforge.org/doc/classes/Rack/Request.html) object is passed to the block (named 'req' in the examples).
 
@@ -157,7 +164,9 @@ end
 ```
 
 
-### Throttles
+### Throttles/Meters
+
+Use meter instead of throttle to log and measure throttle limits before enabling request throttling.
 
 ```ruby
 # Throttle requests to 5 requests per second per ip

--- a/lib/rack/attack/meter.rb
+++ b/lib/rack/attack/meter.rb
@@ -1,0 +1,51 @@
+module Rack
+  class Attack
+    class Meter
+      MANDATORY_OPTIONS = [:limit, :period]
+
+      attr_reader :name, :limit, :period, :block, :type
+
+      def initialize(name, options, block)
+        @name, @block = name, block
+
+        MANDATORY_OPTIONS.each do |opt|
+          raise ArgumentError.new("Must pass #{opt.inspect} option") unless options[opt]
+        end
+
+        @limit  = options[:limit]
+        @period = options[:period].to_i
+        @type   = :meter
+      end
+
+      def cache
+        Rack::Attack.cache
+      end
+
+      def [](req)
+        discriminator = block[req]
+        return false unless discriminator
+
+        key           = "#{name}:#{discriminator}"
+        count         = cache.count(key, period)
+        current_limit = limit.respond_to?(:call) ? limit.call(req) : limit
+        data          = {
+          :count  => count,
+          :period => period,
+          :limit  => current_limit
+        }
+
+        (req.env["rack.attack.#{type.to_s}_data"] ||= {})[name] = data
+
+        (count > current_limit).tap do |limited|
+          if limited
+            req.env['rack.attack.matched']             = name
+            req.env['rack.attack.match_discriminator'] = discriminator
+            req.env['rack.attack.match_type']          = type
+            req.env['rack.attack.match_data']          = data
+            Rack::Attack.instrument(req)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -1,44 +1,9 @@
 module Rack
   class Attack
-    class Throttle
-      MANDATORY_OPTIONS = [:limit, :period]
-      attr_reader :name, :limit, :period, :block
+    class Throttle < Meter
       def initialize(name, options, block)
-        @name, @block = name, block
-        MANDATORY_OPTIONS.each do |opt|
-          raise ArgumentError.new("Must pass #{opt.inspect} option") unless options[opt]
-        end
-        @limit  = options[:limit]
-        @period = options[:period].to_i
-      end
-
-      def cache
-        Rack::Attack.cache
-      end
-
-      def [](req)
-        discriminator = block[req]
-        return false unless discriminator
-
-        key = "#{name}:#{discriminator}"
-        count = cache.count(key, period)
-        current_limit = limit.respond_to?(:call) ? limit.call(req) : limit
-        data = {
-          :count => count,
-          :period => period,
-          :limit => current_limit
-        }
-        (req.env['rack.attack.throttle_data'] ||= {})[name] = data
-
-        (count > current_limit).tap do |throttled|
-          if throttled
-            req.env['rack.attack.matched']             = name
-            req.env['rack.attack.match_discriminator'] = discriminator
-            req.env['rack.attack.match_type']          = :throttle
-            req.env['rack.attack.match_data']          = data
-            Rack::Attack.instrument(req)
-          end
-        end
+        super
+        @type = :throttle
       end
     end
   end

--- a/lib/rack/attack/version.rb
+++ b/lib/rack/attack/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Attack
-    VERSION = '4.0.1'
+    VERSION = '4.0.2'
   end
 end

--- a/spec/rack_attack_meter_spec.rb
+++ b/spec/rack_attack_meter_spec.rb
@@ -1,0 +1,64 @@
+require_relative 'spec_helper'
+describe 'Rack::Attack.meter' do
+  before do
+    @period = 60 # Use a long period; failures due to cache key rotation less likely
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.meter('ip/sec', :limit => 1, :period => @period) { |req| req.ip }
+  end
+
+  it('should have a meter'){ Rack::Attack.meters.key?('ip/sec') }
+  allow_ok_requests
+
+  describe 'a single request' do
+    before { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    it 'should set the counter for one request' do
+      key = "rack::attack:#{Time.now.to_i/@period}:ip/sec:1.2.3.4"
+      Rack::Attack.cache.store.read(key).must_equal 1
+    end
+
+    it 'should populate meter data' do
+      data = { :count => 1, :limit => 1, :period => @period }
+      last_request.env['rack.attack.meter_data']['ip/sec'].must_equal data
+    end
+  end
+  describe "with 2 requests" do
+    before do
+      2.times { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    end
+    it 'should not block the last request' do
+      last_response.status.must_equal 200
+    end
+    it 'should tag the env' do
+      last_request.env['rack.attack.matched'].must_equal 'ip/sec'
+      last_request.env['rack.attack.match_type'].must_equal :meter
+      last_request.env['rack.attack.match_data'].must_equal({:count => 2, :limit => 1, :period => @period})
+      last_request.env['rack.attack.match_discriminator'].must_equal('1.2.3.4')
+    end
+    it 'should not set a Retry-After header' do
+      last_response.headers['Retry-After'].must_be_nil
+    end
+  end
+end
+
+describe 'Rack::Attack.meter with limit as proc' do
+  before do
+    @period = 60 # Use a long period; failures due to cache key rotation less likely
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.meter('ip/sec', :limit => lambda {|req| 1}, :period => @period) { |req| req.ip }
+  end
+
+  allow_ok_requests
+
+  describe 'a single request' do
+    before { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    it 'should set the counter for one request' do
+      key = "rack::attack:#{Time.now.to_i/@period}:ip/sec:1.2.3.4"
+      Rack::Attack.cache.store.read(key).must_equal 1
+    end
+
+    it 'should populate meter data' do
+      data = { :count => 1, :limit => 1, :period => @period }
+      last_request.env['rack.attack.meter_data']['ip/sec'].must_equal data
+    end
+  end
+end


### PR DESCRIPTION
Added new 'meter' functionality to enable production logging and measuring without effecting the request. The current track functionality doesn't have the same options as throttling to determine if the throttling limits are appropriate. With the new meter functionality you can have identical params as throttling to test if your throttling will be too restrictive or cause issues before turning on the actual request throttle.
