### PR TITLE
Support for period ranges

### DIFF
--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -16,8 +16,17 @@ module Rack
 
       def count(unprefixed_key, period)
         epoch_time = Time.now.to_i
-        expires_in = period - (epoch_time % period)
-        key = "#{prefix}:#{(epoch_time/period).to_i}:#{unprefixed_key}"
+        if period.is_a? Range
+          expires_in = period.end - epoch_time
+          # Manually create string representation to force cast both ends to int
+          # (instead of using Range#to_s)
+          period_key = "#{period.begin.to_i}..#{period.end.to_i}"
+        else
+          expires_in = period - (epoch_time % period)
+          period_key = (epoch_time/period).to_i
+        end
+
+        key = "#{prefix}:#{period_key}:#{unprefixed_key}"
         do_count(key, expires_in)
       end
 

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -9,7 +9,7 @@ module Rack
           raise ArgumentError.new("Must pass #{opt.inspect} option") unless options[opt]
         end
         @limit  = options[:limit]
-        @period = options[:period].to_i
+        @period = options[:period]
         @type   = options.fetch(:type, :throttle)
       end
 
@@ -22,11 +22,12 @@ module Rack
         return false unless discriminator
 
         key = "#{name}:#{discriminator}"
-        count = cache.count(key, period)
+        current_period = period.respond_to?(:call) ? period.call(req) : period
         current_limit = limit.respond_to?(:call) ? limit.call(req) : limit
+        count = cache.count(key, current_period)
         data = {
           :count => count,
-          :period => period,
+          :period => current_period,
           :limit => current_limit
         }
         (req.env['rack.attack.throttle_data'] ||= {})[name] = data

--- a/spec/rack_attack_cache_spec.rb
+++ b/spec/rack_attack_cache_spec.rb
@@ -1,0 +1,27 @@
+require_relative 'spec_helper'
+
+describe Rack::Attack::Cache do
+  describe "#count" do
+    before do
+      @cache = Rack::Attack::Cache.new
+      @store = MiniTest::Mock.new
+      @cache.store = @store
+    end
+    describe "with a integer period" do
+      it "should set key with using current time over period" do
+        Time.stub(:now, 30) do
+          @store.expect(:increment, true, ["rack::attack:1:cache-test-key", 1, {expires_in: 20}])
+          @cache.count("cache-test-key", 25)
+        end
+      end
+    end
+    describe "with a range period" do
+      it "should set key with using current time over period" do
+        Time.stub(:now, 6) do
+          @store.expect(:increment, true, ["rack::attack:5..10:cache-test-key", 1, {expires_in: 4}])
+          @cache.count("cache-test-key", (5..10))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Supports range based periods, for the cases when periods needs to be manually defined such as start/end of the month or any particularly different metric.

```
period_based_on_proc = proc {|req| (Time.now.gmtime.beginning_of_month..Time.now.gmtime.end_of_month) }
Rack::Attack.throttle('req/ip', :limit => 100, :period => period_based_on_proc) do |req|
  req.ip
end
```
