### PR TITLE
Adding Conditional Throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ Rack::Attack.throttle('req/ip', :limit => limit_based_on_proc, :period => 1.seco
 end
 ```
 
+### Conditional Throttles
+# Throttle failed logins
+ Rack::Attack.conditional_throttle('login', :limit =>5, :period => 1.hour) do |req|
+ # If the return value is truthy, the cache key for the return value is checked to determine
+ # whether to throttle. The value for the key is not incremented
+
+ # To increment the value returned by key
+ To increment counter
+ if(failed_login)
+     Rack::Attack.increment_throttle_counter('login', request.params['...
+ end
+
 ### Tracks
 
 ```ruby

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -5,6 +5,7 @@ class Rack::Attack
   autoload :Cache,           'rack/attack/cache'
   autoload :Check,           'rack/attack/check'
   autoload :Throttle,        'rack/attack/throttle'
+  autoload :ConditionalThrottle,        'rack/attack/conditional_throttle'
   autoload :Whitelist,       'rack/attack/whitelist'
   autoload :Blacklist,       'rack/attack/blacklist'
   autoload :Track,           'rack/attack/track'
@@ -19,6 +20,10 @@ class Rack::Attack
 
     attr_accessor :notifier, :blacklisted_response, :throttled_response
 
+    def increment_throttle_counter(name, discriminator)
+      self.throttles[name].increment_counter(discriminator)
+    end
+
     def whitelist(name, &block)
       self.whitelists[name] = Whitelist.new(name, block)
     end
@@ -29,6 +34,10 @@ class Rack::Attack
 
     def throttle(name, options, &block)
       self.throttles[name] = Throttle.new(name, options, block)
+    end
+
+    def conditional_throttle(name, options, &block)
+      self.throttles[name] = ConditionalThrottle.new(name, options, block)
     end
 
     def track(name, options = {}, &block)

--- a/lib/rack/attack/conditional_throttle.rb
+++ b/lib/rack/attack/conditional_throttle.rb
@@ -1,0 +1,17 @@
+module Rack
+  class Attack
+    class ConditionalThrottle < ::Rack::Attack::Throttle
+
+      def increment_counter(discriminator)
+        key = "#{name}:#{discriminator}"
+        cache.count(key, period)
+      end
+
+      def get_count(discriminator)
+        key = "#{name}:#{discriminator}"
+        count = cache.get_count(key, period)
+        count ? count.to_i : 0
+      end
+    end
+  end
+end

--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -12,6 +12,13 @@ module Rack
           super(store)
         end
 
+        def raw_read(key)
+          #https://github.com/redis-store/redis-store/issues/96
+          # if raw not specified results in 'marshal data too short' error
+          self.get(key, raw: true)
+        rescue Redis::BaseError
+        end
+
         def read(key)
           self.get(key)
         rescue Redis::BaseError

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -17,12 +17,16 @@ module Rack
         Rack::Attack.cache
       end
 
+      def get_count(discriminator)
+        key = "#{name}:#{discriminator}"
+        cache.count(key, period)
+      end
+
       def [](req)
         discriminator = block[req]
         return false unless discriminator
 
-        key = "#{name}:#{discriminator}"
-        count = cache.count(key, period)
+        count = get_count(discriminator)
         current_limit = limit.respond_to?(:call) ? limit.call(req) : limit
         data = {
           :count => count,

--- a/lib/rack/attack/version.rb
+++ b/lib/rack/attack/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Attack
-    VERSION = '4.1.1'
+    VERSION = '4.1.2'
   end
 end

--- a/spec/rack_attack_conditional_throttle_spec.rb
+++ b/spec/rack_attack_conditional_throttle_spec.rb
@@ -1,0 +1,53 @@
+require_relative 'spec_helper'
+describe 'Rack::Attack.conditional_throttle' do
+  before do
+    @period = 60 # Use a long period; failures due to cache key rotation less likely
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.conditional_throttle('login', :limit => 1, :period => @period) { |req| req.ip }
+  end
+
+  it('should have a throttle'){ Rack::Attack.throttles.key?('login') }
+  allow_ok_requests
+
+  describe 'a single successful request' do
+    before { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    it 'should not set the counter for one request' do
+      key = "rack::attack:#{Time.now.to_i/@period}:login:1.2.3.4"
+      Rack::Attack.cache.store.read(key).must_equal nil
+    end
+  end
+  describe "with 2 requests" do
+    before do
+      2.times { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    end
+    it 'should not block the last request' do
+      last_response.status.must_equal 200
+    end
+  end
+
+  describe 'a successful request followed by failed request' do
+    before { get '/', {}, 'REMOTE_ADDR' => '1.2.3.4' }
+    it 'should increment counter for failed request' do
+      key = "rack::attack:#{Time.now.to_i/@period}:login:1.2.3.4"
+      Rack::Attack.increment_throttle_counter('login', '1.2.3.4')
+      Rack::Attack.cache.store.read(key).must_equal 1
+    end
+  end
+
+  describe 'a successful request followed by two failed request followed by successful request' do
+    before {
+      get '/', {}, 'REMOTE_ADDR' => '1.2.3.4'
+      @key = "rack::attack:#{Time.now.to_i/@period}:login:1.2.3.4"
+      Rack::Attack.increment_throttle_counter('login', '1.2.3.4')
+      Rack::Attack.increment_throttle_counter('login', '1.2.3.4')
+    }
+    it 'should increment counter for failed request' do
+
+      Rack::Attack.cache.store.read(@key).must_equal 2
+      get '/', {}, 'REMOTE_ADDR' => '1.2.3.4'
+      Rack::Attack.cache.store.read(@key).must_equal 2
+      last_response.status.must_equal 429
+    end
+  end
+end
+


### PR DESCRIPTION
Added a ConditionalThrottle filter, which checks to see whether a limit has
been reached but does not increment for each request.

To increment, call the Rack::Attack.increment_counter

Usage (Conditionally throttling on failed logins)

Rack::Attack.conditional_throttle('login',
                        :limit => ...,
                        :period => 1.hour) { |request|
    if is_rate_limited_uri?(request) && request.post?
      request.params['...
    end
  }

To increment counter
if(failed_login)
    Rack::Attack.increment_counter('login', request.params['...
end

This support the use case where one wants to rate limit failed
logins only.
For example, we set a limit of 5 failed logins per hour.
Successful requests do not increment counter, failed requests do
(by an explicit call to increment_counter on failure).
Once that limit is reached, all requests, including correct
logins are blocked until the timout
expires.
In addition, successful logins do not increment/refresh the counter.
