### PR TITLE
Invoke Rack:::{blacklisted,throttled}_response with #call

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ def call(env)
   if whitelisted?(req)
     @app.call(env)
   elsif blacklisted?(req)
-    blacklisted_response[env]
+    self.class.blacklisted_response.call(env)
   elsif throttled?(req)
-    throttled_response[env]
+    self.class.throttled_response.call(env)
   else
     tracked?(req)
     @app.call(env)

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -96,9 +96,9 @@ class Rack::Attack
     if whitelisted?(req)
       @app.call(env)
     elsif blacklisted?(req)
-      self.class.blacklisted_response[env]
+      self.class.blacklisted_response.call(env)
     elsif throttled?(req)
-      self.class.throttled_response[env]
+      self.class.throttled_response.call(env)
     else
       tracked?(req)
       @app.call(env)


### PR DESCRIPTION
I have a response which is a class. While I can still have my class
implement `#[]`, it does look a bit off. On the other side, having
objects responding to `#call` that aren't procs is pretty common.

I propose to invoke the responses with `#call` to let users override
it with response objects, that respond to `#call` instead of `#[]`.
