### PR TITLE
snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Or for Rackup files:
 use Rack::Attack
 ```
 
-Add a `rack-attack.rb` file to `config/initalizers/`:
+Add a `rack_attack.rb` file to `config/initalizers/`:
 ```ruby
 # In config/initializers/rack-attack.rb
 class Rack::Attack


### PR DESCRIPTION
in Rails App filenames need using snake_case instead of kebab-case...
