### PR TITLE
Pass `raw: true` to prevent Ruby de/serialization. This is to make it po...

### DIFF
--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -13,15 +13,15 @@ module Rack
         end
 
         def read(key)
-          self.get(key)
+          self.get(key, raw: true)
         rescue Redis::BaseError
         end
 
         def write(key, value, options={})
           if (expires_in = options[:expires_in])
-            self.setex(key, expires_in, value)
+            self.setex(key, expires_in, value, raw: true)
           else
-            self.set(key, value)
+            self.set(key, value, raw: true)
           end
         rescue Redis::BaseError
         end


### PR DESCRIPTION
...ssible

to implement something like:

```store.write(key, 0, :expires_in => expires_in)```

See #113