### PR TITLE
Added ability to disable.

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -76,6 +76,17 @@ class Rack::Attack
       @whitelists, @blacklists, @throttles, @tracks = {}, {}, {}, {}
     end
 
+    def disable!
+      @disabled = true
+    end
+
+    def enable!
+      @disabled = false
+    end
+
+    def disabled?
+      !!@disabled
+    end
   end
 
   # Set defaults
@@ -91,6 +102,8 @@ class Rack::Attack
   end
 
   def call(env)
+    return @app.call(env) if disabled?
+
     req = Rack::Attack::Request.new(env)
 
     if whitelisted?(req)
@@ -109,5 +122,6 @@ class Rack::Attack
   def_delegators self, :whitelisted?,
                        :blacklisted?,
                        :throttled?,
-                       :tracked?
+                       :tracked?,
+                       :disabled?
 end


### PR DESCRIPTION
I wanted the ability to turn off throttling in most of my specs, but turn it on for specs testing throttling itself.

So my test.rb now looks like this:

```
  # Use a lower ODK Collect request limit for tests
  configatron.direct_auth_request_limit = 5

  # Enable rack-attack middleware for protecting against brute-force login attempts,
  # but disable it until needed.
  config.middleware.use Rack::Attack
  Rack::Attack.disable!
```

And then I use `before` and `after` blocks to enable/re-disable it when needed.

Would be great to get this in the main build.

Thanks!