### PR TITLE
Record hit names

### DIFF
--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -21,6 +21,8 @@ module Rack
         discriminator = block[req]
         return false unless discriminator
 
+        (req.env['rack.attack.hit_names'] ||= []) << name
+
         current_period = period.respond_to?(:call) ? period.call(req) : period
         current_limit  = limit.respond_to?(:call) ? limit.call(req) : limit
         key            = "#{name}:#{discriminator}"


### PR DESCRIPTION
In #29, @ktheory mentioned: 
> modifying app response headers feels like a big increase in the scope of rack-attack

I agree, but I think the hit names, which means which throttle names have hited is usefully for rate limit implementation.

Hope it can be included soon eagerly.