### PR TITLE
Add note to README.md about scoping of Fail2Ban filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Rack::Attack.blacklist('fail2ban pentesters') do |req|
 end
 ```
 
+Note that `Fail2Ban` filters are not automatically scoped to the blacklist, so when using multiple filters in an application the scoping must be added to the discriminator e.g. `"pentest:#{req.ip}"`.
+
 #### Allow2Ban
 `Allow2Ban.filter` works the same way as the `Fail2Ban.filter` except that it *allows* requests from misbehaving
 clients until such time as they reach maxretry at which they are cut off as per normal.


### PR DESCRIPTION
I see it has been closed, but I also got tripped up by #132.  I'd like to add a note to the README to avoid confusion.