### PR TITLE
Development testing improvements with guard and pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
+
 gemspec
 
-#gem 'debugger', platform: 'ruby'
+group :development do
+  gem 'pry'
+  gem 'guard' # NB: this is necessary in newer versions
+  gem 'guard-minitest'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,10 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard :minitest do
+  # with Minitest::Spec
+  watch(%r{^spec/(.*)_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})         { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^spec/spec_helper\.rb$}) { 'spec' }
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,9 @@ require 'active_support'
 require "rack/attack"
 
 begin
-  require 'debugger'
+  require 'pry'
 rescue LoadError
- #nothing to do here
+  #nothing to do here
 end
 
 class MiniTest::Spec


### PR DESCRIPTION
Allows running tests with `bundle exec guard`.

Also use `pry` instead of `debugger`.