### PR TITLE
Refactor StoreProxy to avoid autoloading MemCacheStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+  - Fix an error affecting apps using Redis::Store saying that dalli was a
+    required dependency. Learn about ActiveSupport autoloading. (#165)
+
 ## v4.4.0 - 10 Feb 2016
 
   - New: support for MemCacheStore (#153). Thanks @elhu.

--- a/lib/rack/attack/version.rb
+++ b/lib/rack/attack/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Attack
-    VERSION = '4.4.0'
+    VERSION = '4.4.1'
   end
 end


### PR DESCRIPTION
In v4.4.0, checking `defined?(ActiveSupport::Cache::MemCacheStore)`
could trigger an error loading dalli, which isn’t needed.

This fixes that bug, and prevents similar bugs by checking
`store.class.to_s` rather than `defined?(klass) && store.is_a?(klass)`.

Writing an automated test to ensure that dalli is truly optional is
difficult, but I was able to recreate the dalli load error in v4.4.0 by
running:

```bash
gem uninstall dalli
ruby -Ilib -ractive_support/all -ractive_support/cache/redis_store -rrack/attack -e 'p Rack::Attack::StoreProxy.build(Redis::Store.new)'
```

Fixes #163