### PR TITLE
Add a lazily-loaded, memoized Rack::Attack#ip_addr helper.

### DIFF
--- a/lib/rack/attack/request.rb
+++ b/lib/rack/attack/request.rb
@@ -1,3 +1,5 @@
+require 'ipaddr'
+
 # Rack::Attack::Request is the same as ::Rack::Request by default.
 #
 # This is a safe place to add custom helper methods to the request object
@@ -14,6 +16,10 @@
 module Rack
   class Attack
     class Request < ::Rack::Request
+      # A memoized instance of an IPAddr, derived from the "ip" value.
+      def ip_addr
+        @ip_addr ||= IPAddr.new(ip)
+      end
     end
   end
 end

--- a/spec/rack_attack_request_spec.rb
+++ b/spec/rack_attack_request_spec.rb
@@ -15,5 +15,13 @@ describe 'Rack::Attack' do
     end
 
     allow_ok_requests
+
+    it 'lazily instantiates and memoizes an IPAddr object around the ip' do
+      req = Rack::Attack::Request.new({'REMOTE_ADDR' => '1.2.3.4'})
+      ip_addr = req.ip_addr
+
+      ip_addr.must_be_instance_of IPAddr
+      ip_addr.must_be_same_as req.ip_addr
+    end
   end
 end


### PR DESCRIPTION
[`IPAddr`](http://ruby-doc.org/stdlib-2.3.0/libdoc/ipaddr/rdoc/IPAddr.html) tends to be very useful in tandem with Rack::Attack (checking ipv4 vs ipv6, matching against CIDR blocks, etc). This lazily wraps and memoizes an instance of `IPAddr` as a `Rack::Attack::Request` helper.

cc @ktheory 