### PR TITLE
Fixnum error rails 4.2.6 fix

### DIFF
--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -40,8 +40,9 @@ module Rack
 
       def key_and_expiry(unprefixed_key, period)
         epoch_time = Time.now.to_i
+        period = period.to_i
         # Add 1 to expires_in to avoid timing error: http://git.io/i1PHXA
-        expires_in = (period.to_i - (epoch_time % period.to_i) + 1).to_i
+        expires_in = (period - (epoch_time % period) + 1).to_i
         ["#{prefix}:#{(epoch_time / period).to_i}:#{unprefixed_key}", expires_in]
       end
 

--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -41,7 +41,7 @@ module Rack
       def key_and_expiry(unprefixed_key, period)
         epoch_time = Time.now.to_i
         # Add 1 to expires_in to avoid timing error: http://git.io/i1PHXA
-        expires_in = (period - (epoch_time % period) + 1).to_i
+        expires_in = (period.to_i - (epoch_time % period.to_i) + 1).to_i
         ["#{prefix}:#{(epoch_time / period).to_i}:#{unprefixed_key}", expires_in]
       end
 


### PR DESCRIPTION
After updating to rails 4.2.6 (ruby 2.3.0) I got the error below. This fix fixes the error.

`TypeError (String can't be coerced into Fixnum):
  rack-attack (4.4.1) lib/rack/attack/cache.rb:44:in `%'
  rack-attack (4.4.1) lib/rack/attack/cache.rb:44:in `key_and_expiry'
  rack-attack (4.4.1) lib/rack/attack/cache.rb:18:in `count'
  rack-attack (4.4.1) lib/rack/attack/throttle.rb:27:in `[]'
  rack-attack (4.4.1) lib/rack/attack.rb:59:in `block in throttled?'
  rack-attack (4.4.1) lib/rack/attack.rb:58:in `any?'
  rack-attack (4.4.1) lib/rack/attack.rb:58:in `throttled?'
  rack-attack (4.4.1) lib/rack/attack.rb:103:in `call'
  warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.6) lib/warden/manager.rb:34:in `catch'
  warden (1.2.6) lib/warden/manager.rb:34:in `call'
  rack (1.6.4) lib/rack/etag.rb:24:in `call'
  rack (1.6.4) lib/rack/conditionalget.rb:25:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.6) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.6) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  activerecord (4.2.6) lib/active_record/migration.rb:377:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.6) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.6) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.6) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  rack-contrib (1.4.0) lib/rack/contrib/response_headers.rb:17:in `call'
  meta_request (0.4.0) lib/meta_request/middlewares/headers.rb:16:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.6) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `call'
  quiet_assets (1.1.0) lib/quiet_assets.rb:27:in `call_with_quiet_assets'
  actionpack (4.2.6) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.4) lib/rack/runtime.rb:18:in `call'
  rack (1.6.4) lib/rack/lock.rb:17:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/static.rb:120:in `call'
  rack (1.6.4) lib/rack/sendfile.rb:113:in `call'
  utf8-cleaner (0.0.9) lib/utf8-cleaner/middleware.rb:18:in `call'
  railties (4.2.6) lib/rails/engine.rb:518:in `call'
  railties (4.2.6) lib/rails/application.rb:165:in `call'
  railties (4.2.6) lib/rails/railtie.rb:194:in `public_send'
  railties (4.2.6) lib/rails/railtie.rb:194:in `method_missing'
  /usr/lib/ruby/vendor_ruby/phusion_passenger/rack/thread_handler_extension.rb:97:in `process_request'
  /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:152:in `accept_and_process_next_request'
  /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler/thread_handler.rb:113:in `main_loop'
  /usr/lib/ruby/vendor_ruby/phusion_passenger/request_handler.rb:416:in `block (3 levels) in start_threads'
  /usr/lib/ruby/vendor_ruby/phusion_passenger/utils.rb:113:in `block in create_thread_and_abort_on_exception'


  Rendered /home/vagrant/.gem/ruby/2.3.0/gems/actionpack-4.2.6/lib/action_dispatch/middleware/templates/rescues/_source.erb (2.5ms)
  Rendered /home/vagrant/.gem/ruby/2.3.0/gems/actionpack-4.2.6/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (1.7ms)
  Rendered /home/vagrant/.gem/ruby/2.3.0/gems/actionpack-4.2.6/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.7ms)
  Rendered /home/vagrant/.gem/ruby/2.3.0/gems/actionpack-4.2.6/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb within rescues/layout (17.4ms)`