### PR TITLE
Controversial Language Change Suggestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin
 .bundle
 *.gem
 *.gemfile.lock
+.ruby-version
+.ruby-gemset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ## v4.2.0 - 26 Oct 2014
  - Throttle's `period` argument now takes a proc as well as a number (thanks @gsamokovarov)
- - Invoke the `#call` method on `blacklist_response` and `throttle_response` instead of `#[]`, as per the Rack spec. (thanks @gsamokovarov)
+ - Invoke the `#call` method on `blocklist_response` and `throttle_response` instead of `#[]`, as per the Rack spec. (thanks @gsamokovarov)
 
 ## v4.1.1 - 11 Sept 2014
  - Fix a race condition in throttles that could allow more requests than intended.
@@ -35,7 +35,7 @@
 ## v4.1.0 - 22 May 2014
  - Tracks take an optional limit and period to only notify once a threshold
    is reached (similar to throttles). Thanks @chiliburger!
- - Default throttled & blacklist responses have Content-Type: text/plain
+ - Default throttled & blocklist responses have Content-Type: text/plain
  - Rack::Attack.clear! resets tracks
 
 ## v4.0.1 - 14 May 2014
@@ -49,7 +49,7 @@
  * Test more dalli versions.
 
 ## v3.0.0 - 15 March 2014
- * Change default blacklisted response to 403 Forbidden (thanks @carpodaster).
+ * Change default blocklisted response to 403 Forbidden (thanks @carpodaster).
  * Fail gracefully when Redis store is not available; rescue exeption and don't
    throttle request. (thanks @wkimeria)
  * TravisCI runs integration tests.
@@ -62,7 +62,7 @@
 ## v2.2.1 - 13 August 2013
  * Add license to gemspec
  * Support ruby version 1.9.2
- * Change default blacklisted response code from 503 to 401; throttled response
+ * Change default blocklisted response code from 503 to 401; throttled response
    from 503 to 429.
 
 ## v2.2.0 - 20 June 2013

--- a/examples/rack_attack.rb
+++ b/examples/rack_attack.rb
@@ -15,12 +15,12 @@ Rack::Attack.throttle "logins/email", :limit => 2, :period => 60 do |req|
   req.post? && req.path == "/login" && req.params['email']
 end
 
-# Blacklist bad IPs from accessing admin pages
-Rack::Attack.blacklist "bad_ips from logging in" do |req|
+# blocklist bad IPs from accessing admin pages
+Rack::Attack.blocklist "bad_ips from logging in" do |req|
   req.path =~ /^\/admin/ && bad_ips.include?(req.ip)
 end
 
-# Whitelist a User-Agent
-Rack::Attack.whitelist 'internal user agent' do |req|
+# safelist a User-Agent
+Rack::Attack.safelist 'internal user agent' do |req|
   req.user_agent == 'InternalUserAgent'
 end

--- a/lib/rack/attack/blocklist.rb
+++ b/lib/rack/attack/blocklist.rb
@@ -1,12 +1,11 @@
 module Rack
   class Attack
-    class Blacklist < Check
+    class Blocklist < Check
       def initialize(name, block)
         super
-        @type = :blacklist
+        @type = :blocklist
       end
 
     end
   end
 end
-

--- a/lib/rack/attack/fail2ban.rb
+++ b/lib/rack/attack/fail2ban.rb
@@ -8,7 +8,7 @@ module Rack
           maxretry  = options[:maxretry]  or raise ArgumentError, "Must pass maxretry option"
 
           if banned?(discriminator)
-            # Return true for blacklist
+            # Return true for blocklist
             true
           elsif yield
             fail!(discriminator, bantime, findtime, maxretry)

--- a/lib/rack/attack/request.rb
+++ b/lib/rack/attack/request.rb
@@ -9,7 +9,7 @@
 #     end
 #   end
 #
-#   Rack::Attack.whitelist("localhost") {|req| req.localhost? }
+#   Rack::Attack.safelist("localhost") {|req| req.localhost? }
 #
 module Rack
   class Attack

--- a/lib/rack/attack/safelist.rb
+++ b/lib/rack/attack/safelist.rb
@@ -1,9 +1,9 @@
 module Rack
   class Attack
-    class Whitelist < Check
+    class Safelist < Check
       def initialize(name, block)
         super
-        @type = :whitelist
+        @type = :safelist
       end
 
     end

--- a/spec/allow2ban_spec.rb
+++ b/spec/allow2ban_spec.rb
@@ -7,7 +7,7 @@ describe 'Rack::Attack.Allow2Ban' do
     @bantime  = 60
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     @f2b_options = {:bantime => @bantime, :findtime => @findtime, :maxretry => 2}
-    Rack::Attack.blacklist('pentest') do |req|
+    Rack::Attack.blocklist('pentest') do |req|
       Rack::Attack::Allow2Ban.filter(req.ip, @f2b_options){req.query_string =~ /OMGHAX/}
     end
   end

--- a/spec/fail2ban_spec.rb
+++ b/spec/fail2ban_spec.rb
@@ -7,7 +7,7 @@ describe 'Rack::Attack.Fail2Ban' do
     @bantime  = 60
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     @f2b_options = {:bantime => @bantime, :findtime => @findtime, :maxretry => 2}
-    Rack::Attack.blacklist('pentest') do |req|
+    Rack::Attack.blocklist('pentest') do |req|
       Rack::Attack::Fail2Ban.filter(req.ip, @f2b_options){req.query_string =~ /OMGHAX/}
     end
   end

--- a/spec/rack_attack_request_spec.rb
+++ b/spec/rack_attack_request_spec.rb
@@ -9,7 +9,7 @@ describe 'Rack::Attack' do
         end
       end
 
-      Rack::Attack.whitelist('valid IP') do |req|
+      Rack::Attack.safelist('valid IP') do |req|
         req.remote_ip == "127.0.0.1"
       end
     end

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -5,7 +5,7 @@ describe 'Rack::Attack' do
 
   describe 'normalizing paths' do
     before do
-      Rack::Attack.blacklist("banned_path") {|req| req.path == '/foo' }
+      Rack::Attack.blocklist("banned_path") {|req| req.path == '/foo' }
     end
 
     it 'blocks requests with trailing slash' do
@@ -14,47 +14,62 @@ describe 'Rack::Attack' do
     end
   end
 
-  describe 'blacklist' do
+  describe 'blocklist' do
     before do
       @bad_ip = '1.2.3.4'
-      Rack::Attack.blacklist("ip #{@bad_ip}") {|req| req.ip == @bad_ip }
+      Rack::Attack.blocklist("ip #{@bad_ip}") {|req| req.ip == @bad_ip }
     end
 
-    it('has a blacklist') {
-      Rack::Attack.blacklists.key?("ip #{@bad_ip}").must_equal true
+    it('has a blocklist') {
+      Rack::Attack.blocklists.key?("ip #{@bad_ip}").must_equal true
+    }
+    
+    it('has a blacklist with a deprication warning') {
+      stdout, stderror  = capture_io do
+        Rack::Attack.blacklists.key?("ip #{@bad_ip}").must_equal true
+      end
+      assert_match "[DEPRECATION] 'blacklists' is deprecated.  Please use 'blocklists' instead.", stderror
     }
 
     describe "a bad request" do
       before { get '/', {}, 'REMOTE_ADDR' => @bad_ip }
-      it "should return a blacklist response" do
+      it "should return a blocklist response" do
         get '/', {}, 'REMOTE_ADDR' => @bad_ip
         last_response.status.must_equal 403
         last_response.body.must_equal "Forbidden\n"
       end
       it "should tag the env" do
         last_request.env['rack.attack.matched'].must_equal "ip #{@bad_ip}"
-        last_request.env['rack.attack.match_type'].must_equal :blacklist
+        last_request.env['rack.attack.match_type'].must_equal :blocklist
       end
 
       allow_ok_requests
     end
 
-    describe "and whitelist" do
+    describe "and safelist" do
       before do
         @good_ua = 'GoodUA'
-        Rack::Attack.whitelist("good ua") {|req| req.user_agent == @good_ua }
+        Rack::Attack.safelist("good ua") {|req| req.user_agent == @good_ua }
       end
 
-      it('has a whitelist'){ Rack::Attack.whitelists.key?("good ua") }
-      describe "with a request match both whitelist & blacklist" do
+      it('has a safelist'){ Rack::Attack.safelists.key?("good ua") }
+
+      it('has a whitelist with a deprication warning') {
+        stdout, stderror  = capture_io do
+          Rack::Attack.whitelists.key?("good ua")
+        end
+        assert_match "[DEPRECATION] 'whitelists' is deprecated.  Please use 'safelists' instead.", stderror
+      }
+
+      describe "with a request match both safelist & blocklist" do
         before { get '/', {}, 'REMOTE_ADDR' => @bad_ip, 'HTTP_USER_AGENT' => @good_ua }
-        it "should allow whitelists before blacklists" do
+        it "should allow safelists before blocklists" do
           get '/', {}, 'REMOTE_ADDR' => @bad_ip, 'HTTP_USER_AGENT' => @good_ua
           last_response.status.must_equal 200
         end
         it "should tag the env" do
           last_request.env['rack.attack.matched'].must_equal 'good ua'
-          last_request.env['rack.attack.match_type'].must_equal :whitelist
+          last_request.env['rack.attack.match_type'].must_equal :safelist
         end
       end
     end


### PR DESCRIPTION
Hello! 
  At Travis CI we've decided to change our usage of Whitelist/Blacklist to the less racially charged language of Safelist/Blocklist. We are using rack-attack and would love to use an updated version with our language choices if you are open to this change. I'm not sure how you would like to change the versioning of this so I didn't add any changes there. I know this would require users to update all of their whitelist/blacklist method calls to the new verbiage, which might annoy a number of end users. However, we did this with a simple find and replace (and method aliases until this change is welcomed). I added the depreciation warnings for the old method names to help users, however if anyone is relying on the rack.attack.match_type I changed it to safelist/blocklist (wasn't sure how to deprecate that nicely). 
Thanks!
**Renée