### PR TITLE
Drop tests for ruby 2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
   - jruby-19mode
 
 gemfile:


### PR DESCRIPTION
It’s EOL, so we’re not supporting it anymore.