### PR TITLE
[tests] Fix gotcha with new activesupport redis versions

### DIFF
--- a/spec/integration/offline_spec.rb
+++ b/spec/integration/offline_spec.rb
@@ -1,5 +1,5 @@
 require 'active_support/cache'
-require 'active_support/cache/redis_store'
+require 'redis-activesupport'
 require 'dalli'
 require_relative '../spec_helper'
 


### PR DESCRIPTION
This fixes the error:

    uninitialized constant ActiveSupport::VERSION

when loading active_support/cache/redis_store