### PR TITLE
Fix args to deprecated methods

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -68,9 +68,9 @@ class Rack::Attack
       end
     end
 
-    def whitelisted?
+    def whitelisted?(req)
       warn "[DEPRECATION] 'Rack::Attack.whitelisted?' is deprecated.  Please use 'safelisted?' instead."
-      safelisted?
+      safelisted?(req)
     end
 
     def blocklisted?(req)
@@ -79,9 +79,9 @@ class Rack::Attack
       end
     end
 
-    def blacklisted?
+    def blacklisted?(req)
       warn "[DEPRECATION] 'Rack::Attack.blacklisted?' is deprecated.  Please use 'blocklisted?' instead."
-      blocklisted?
+      blocklisted?(req)
     end
 
     def throttled?(req)

--- a/lib/rack/attack/version.rb
+++ b/lib/rack/attack/version.rb
@@ -1,5 +1,5 @@
 module Rack
   class Attack
-    VERSION = '5.0.0'
+    VERSION = '5.0.1'
   end
 end


### PR DESCRIPTION
Fixes #197.

NB: `safelisted?` and `blocklisted?` should be considered unstable Rack::Attack api methods.