### PR TITLE
Travis: use JRuby latest stable 9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
-  - jruby-9.1.5.0
+  - jruby-9.1.7.0
 
 gemfile:
   - gemfiles/activesupport4.1.gemfile


### PR DESCRIPTION
Hi, this PR only bumps the JRuby to latest released stable.