### PR TITLE
Rspec rails test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ A note on developing and testing apps using Rack::Attack - if you are using thro
 need to enable the cache in your development environment. See [Caching with Rails](http://guides.rubyonrails.org/caching_with_rails.html)
 for more on how to do this.
 
+If using rspec - you can use `require 'rack/attack/rspec'` in order to disable Rack Attack in tests (so that you do not throttle or blocklist during test executions causing 'flakey' tests). You can selectively enable Rack Attack by using `rack_attack: true` in a block.
+
 ## Performance
 
 The overhead of running Rack::Attack is typically negligible (a few milliseconds per request),

--- a/lib/rack/attack/rspec.rb
+++ b/lib/rack/attack/rspec.rb
@@ -1,0 +1,32 @@
+require 'rack/attack'
+require 'rspec/core'
+
+throttles = Rack::Attack.throttles
+blocklists = Rack::Attack.blocklists
+safelists = Rack::Attack.safelists
+tracks = Rack::Attack.tracks
+
+Rack::Attack.clear!
+
+RSpec.configure do |config|
+  config.around(:each, rack_attack: true) do |ex|
+    throttles.reduce(Rack::Attack) do |acc, (name, t)|
+      acc.throttle(name, {limit: t.limit, period: t.period}, &t.block)
+      acc
+    end
+    blocklists.reduce(Rack::Attack) do |acc, (name, b)|
+      acc.blocklist(name, &b.block)
+      acc
+    end
+    safelists.reduce(Rack::Attack) do |acc, (name, s)|
+      acc.safelist(name, &s.block)
+      acc
+    end
+    tracks.reduce(Rack::Attack) do |acc, (name, track)|
+      acc.track(name, {limit: track.filter.try(:limit), period: track.filter.try(:period)}, track.filter.block)
+      acc
+    end
+    ex.run
+    Rack::Attack.clear!
+  end
+end


### PR DESCRIPTION
Disable Rack Attack in tests (so that integration tests do not get 'random' failures caused by throttling or blocklisting). Tests can selectively enable Rack Attack by including `rack_attack: true` in a block (describe/context)