### PR TITLE
Travis: use latest jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 
 gemfile:
   - gemfiles/activesupport4.1.gemfile


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html