### PR TITLE
Update docs to use new ruby hash syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ how the parameters work.  For multiple filters, be sure to put each filter in a 
 Rack::Attack.blocklist('fail2ban pentesters') do |req|
   # `filter` returns truthy value if request fails, or if it's from a previously banned IP
   # so the request is blocked
-  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", :maxretry => 3, :findtime => 10.minutes, :bantime => 5.minutes) do
+  Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 3, findtime: 10.minutes, bantime: 5.minutes) do
     # The count for the IP is incremented if the return value is truthy
     CGI.unescape(req.query_string) =~ %r{/etc/passwd} ||
     req.path.include?('/etc/passwd') ||
@@ -163,7 +163,7 @@ Rack::Attack.blocklist('allow2ban login scrapers') do |req|
   # `filter` returns false value if request is to your login page (but still
   # increments the count) so request below the limit are not blocked until
   # they hit the limit.  At that point, filter will return true and block.
-  Rack::Attack::Allow2Ban.filter(req.ip, :maxretry => 20, :findtime => 1.minute, :bantime => 1.hour) do
+  Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 20, findtime: 1.minute, bantime: 1.hour) do
     # The count for the IP is incremented if the return value is truthy.
     req.path == '/login' and req.post?
   end
@@ -175,7 +175,7 @@ end
 
 ```ruby
 # Throttle requests to 5 requests per second per ip
-Rack::Attack.throttle('req/ip', :limit => 5, :period => 1.second) do |req|
+Rack::Attack.throttle('req/ip', limit: 5, period: 1.second) do |req|
   # If the return value is truthy, the cache key for the return value
   # is incremented and compared with the limit. In this case:
   #   "rack::attack:#{Time.now.to_i/1.second}:req/ip:#{req.ip}"
@@ -187,7 +187,7 @@ end
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /login requests
-Rack::Attack.throttle('logins/email', :limit => 6, :period => 60.seconds) do |req|
+Rack::Attack.throttle('logins/email', limit: 6, period: 60.seconds) do |req|
   req.params['email'] if req.path == '/login' && req.post?
 end
 
@@ -195,7 +195,7 @@ end
 # Rack::Auth::Basic has authenticated the user:
 limit_proc = proc {|req| req.env["REMOTE_USER"] == "admin" ? 100 : 1}
 period_proc = proc {|req| req.env["REMOTE_USER"] == "admin" ? 1.second : 1.minute}
-Rack::Attack.throttle('req/ip', :limit => limit_proc, :period => period_proc) do |req|
+Rack::Attack.throttle('req/ip', limit: limit_proc, period: period_proc) do |req|
   req.ip
 end
 ```
@@ -209,7 +209,7 @@ Rack::Attack.track("special_agent") do |req|
 end
 
 # Supports optional limit and period, triggers the notification only when the limit is reached.
-Rack::Attack.track("special_agent", :limit => 6, :period => 60.seconds) do |req|
+Rack::Attack.track("special_agent", limit: 6, period: 60.seconds) do |req|
   req.user_agent == "SpecialAgent"
 end
 

--- a/examples/rack_attack.rb
+++ b/examples/rack_attack.rb
@@ -3,15 +3,15 @@
 # Throttle 10 requests/ip/second
 # NB: return value of block is key name for counter
 #     falsy values bypass throttling
-Rack::Attack.throttle("req/ip", :limit => 10, :period => 1) { |req| req.ip }
+Rack::Attack.throttle("req/ip", limit: 10, period: 1) { |req| req.ip }
 
 # Throttle attempts to a particular path. 2 POSTs to /login per second per IP
-Rack::Attack.throttle "logins/ip", :limit => 2, :period => 1 do |req|
+Rack::Attack.throttle "logins/ip", limit: 2, period: 1 do |req|
   req.post? && req.path == "/login" && req.ip
 end
 
 # Throttle login attempts per email, 10/minute/email
-Rack::Attack.throttle "logins/email", :limit => 2, :period => 60 do |req|
+Rack::Attack.throttle "logins/email", limit: 2, period: 60 do |req|
   req.post? && req.path == "/login" && req.params['email']
 end
 


### PR DESCRIPTION
So that gem users don't get the old hash syntax when copy-pasting examples into their app code.