### PR TITLE
Only test against actively supported rubies and gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rvm:
   - 2.2.9
   - jruby-9.1.14.0
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 gemfile:
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.5.0
+  - 2.4.3
+  - 2.3.6
+  - 2.2.9
   - jruby-9.1.14.0
 
 gemfile:
-  - gemfiles/activesupport4.1.gemfile
-  - gemfiles/activesupport4.2.gemfile
+  - gemfiles/rails_5_1.gemfile
+  - gemfiles/rails_5_0.gemfile
+  - gemfiles/rails_4_2.gemfile
   - gemfiles/dalli2.gemfile
 
 services:

--- a/Appraisals
+++ b/Appraisals
@@ -1,25 +1,16 @@
-appraise 'activesupport3.2' do
-  gem 'activesupport', '~> 3.2.0'
-  gem 'actionpack', '~> 3.2.0'
+appraise 'rails_5-1' do
+  gem 'activesupport', '~> 5.1.0'
+  gem 'actionpack', '~> 5.1.0'
 end
 
-appraise 'activesupport4.0' do
-  gem 'activesupport', '~> 4.0.0'
-  gem 'actionpack', '~> 4.0.0'
+appraise 'rails_5-0' do
+  gem 'activesupport', '~> 5.0.0'
+  gem 'actionpack', '~> 5.0.0'
 end
 
-appraise 'activesupport4.1' do
-  gem 'activesupport', '~> 4.1.0'
-  gem 'actionpack', '~> 4.1.0'
-end
-
-appraise 'activesupport4.2' do
+appraise 'rails_4-2' do
   gem 'activesupport', '~> 4.2.0'
   gem 'actionpack', '~> 4.2.0'
-end
-
-appraise 'dalli1.1' do
-  gem 'dalli', '1.1.5'
 end
 
 appraise 'dalli2' do

--- a/gemfiles/dalli2.gemfile
+++ b/gemfiles/dalli2.gemfile
@@ -3,9 +3,6 @@
 source "https://rubygems.org"
 
 gem "dalli", "~> 2.0"
-gem "rack", "<= 1.4.7", platforms: [:ruby_21, :jruby]
-gem "activesupport", "<= 3.2.22.2", platforms: [:ruby_21, :jruby]
-gem "listen", "<= 3.0.6", platforms: [:ruby_21, :jruby]
 
 group :development do
   gem "pry"
@@ -13,4 +10,4 @@ group :development do
   gem "guard-minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 4.2.0"
 gem "actionpack", "~> 4.2.0"
-gem "listen", "<= 3.0.6", platforms: [:ruby_21, :jruby]
 
 group :development do
   gem "pry"
@@ -12,4 +11,4 @@ group :development do
   gem "guard-minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "activesupport", "~> 5.0.0"
 gem "actionpack", "~> 5.0.0"
-gem "listen", "<= 3.0.6", platforms: [:ruby_21, :jruby]
 
 group :development do
   gem "pry"
@@ -12,4 +11,4 @@ group :development do
   gem "guard-minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -2,9 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activesupport", "~> 4.1.0"
-gem "actionpack", "~> 4.1.0"
-gem "listen", "<= 3.0.6", platforms: [:ruby_21, :jruby]
+gem "activesupport", "~> 5.1.0"
+gem "actionpack", "~> 5.1.0"
 
 group :development do
   gem "pry"
@@ -12,4 +11,4 @@ group :development do
   gem "guard-minitest"
 end
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
This PR updates both appraisal and travis configs to run tests (locally or in CI) against only the actively maintained ruby, rails and dalli versions.

Reference links:

* https://www.ruby-lang.org/en/downloads/branches://www.ruby-lang.org/en/downloads/branches/
* http://guides.rubyonrails.org/maintenance_policy.html
* https://www.ruby-lang.org/en/downloads/releases/