### PR TITLE
Adds acceptance-oriented tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,13 @@ namespace :test do
   Rake::TestTask.new(:integration) do |t|
     t.pattern = "spec/integration/*_spec.rb"
   end
+
+  Rake::TestTask.new(:acceptance) do |t|
+    t.pattern = "spec/acceptance/*_spec.rb"
+  end
 end
 
 desc 'Run tests'
-task :test => %w[test:units test:integration]
+task :test => %w[test:units test:integration test:acceptance]
 
 task :default => :test

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'dalli'
   s.add_development_dependency 'connection_pool'
   s.add_development_dependency 'memcache-client'
+  s.add_development_dependency "timecop"
 end

--- a/spec/acceptance/blocking_spec.rb
+++ b/spec/acceptance/blocking_spec.rb
@@ -1,0 +1,21 @@
+require_relative "../spec_helper"
+
+describe "#blocklist" do
+  before do
+    Rack::Attack.blocklist("block 1.2.3.4") do |request|
+      request.ip == "1.2.3.4"
+    end
+  end
+
+  it "forbids request if blocklist condition is true" do
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 403, last_response.status
+  end
+
+  it "succeeds if blocklist condition is false" do
+    get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
+
+    assert_equal 200, last_response.status
+  end
+end

--- a/spec/acceptance/safelisting_spec.rb
+++ b/spec/acceptance/safelisting_spec.rb
@@ -1,0 +1,37 @@
+require_relative "../spec_helper"
+
+describe "#safelist" do
+  before do
+    Rack::Attack.blocklist("block 1.2.3.4") do |request|
+      request.ip == "1.2.3.4"
+    end
+
+    Rack::Attack.safelist("safe path") do |request|
+      request.path == "/safe_space"
+    end
+  end
+
+  it "forbids request if blocklist condition is true and safelist is false" do
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 403, last_response.status
+  end
+
+  it "succeeds if blocklist condition is false and safelist is false" do
+    get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
+
+    assert_equal 200, last_response.status
+  end
+
+  it "succeeds request if blocklist condition is false and safelist is true" do
+    get "/safe_space", {}, "REMOTE_ADDR" => "5.6.7.8"
+
+    assert_equal 200, last_response.status
+  end
+
+  it "succeeds request if both blocklist and safelist conditions are true" do
+    get "/safe_space", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 200, last_response.status
+  end
+end

--- a/spec/acceptance/throttling_spec.rb
+++ b/spec/acceptance/throttling_spec.rb
@@ -1,0 +1,30 @@
+require_relative "../spec_helper"
+require "timecop"
+
+describe "#throttle" do
+  it "allows one request per minute by IP" do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    Rack::Attack.throttle("by ip", limit: 1, period: 60) do |request|
+      request.ip
+    end
+
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 200, last_response.status
+
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 429, last_response.status
+
+    get "/", {}, "REMOTE_ADDR" => "5.6.7.8"
+
+    assert_equal 200, last_response.status
+
+    Timecop.travel(60) do
+      get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+      assert_equal 200, last_response.status
+    end
+  end
+end


### PR DESCRIPTION
Thought it might be a good idea to start a directory with tests which only focus is asserting what user expectations are about the gem public API/contract, without any assertions about internals.

These are very basic yet.
More to come if there's agreement it's a good idea :-)