### PR TITLE
[Fixes #253] Avoid 'defined?' buggy behavior in ruby 2.5.0

### DIFF
--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -5,7 +5,14 @@ module Rack
     module StoreProxy
       class RedisStoreProxy < SimpleDelegator
         def self.handle?(store)
-          defined?(::Redis::Store) && store.is_a?(::Redis::Store)
+          # Using const_defined? for now.
+          #
+          # Go back to use defined? once this ruby issue is
+          # fixed and released:
+          # https://bugs.ruby-lang.org/issues/14407
+          #
+          # defined?(::Redis::Store) && store.is_a?(::Redis::Store)
+          const_defined?("::Redis::Store") && store.is_a?(::Redis::Store)
         end
 
         def initialize(store)


### PR DESCRIPTION
Fixes #253 

Found that `defined?` is buggy in ruby 2.5.0, which under certain circumstances users using rack-attack can hit (see [minimal app to reproduce issue 253](https://github.com/grzuy/ruby_app_for_rack_attack_253)).

I already reported (https://bugs.ruby-lang.org/issues/14407) and fixed (https://github.com/ruby/ruby/pull/1800) the underlaying issue in ruby, but i am guessing it's going to take some time before there's a new ruby release including the fix.

So for now, we would need to circumvent this ruby 2.5.0 bug by using `Object#const_defined?` instead of `defined?`, at least for this particular case.

---

__More details__:

Anyone using:
  * ruby 2.5.0
  * redis
  * rack-attack without redis-store and using at least one throttle
  * having a toplevel class named Store

will hit this ruby 2.5.0 bug https://bugs.ruby-lang.org/issues/14407

That's because of the following buggy behavior of `defined?` under ruby 2.5.0:

```
$ ruby -v
ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]

$ irb
> class Redis
> end
=> nil
> class Store
> end
=> nil
> defined?(::Redis::Store)
=> "constant"
> ::Redis::Store
  NameError (uninitialized constant Redis::Store
    Did you mean?  Store)
```