### PR TITLE
Don't make README examples depend on activesupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ end
 
 # Throttle login attempts for a given email parameter to 6 reqs/minute
 # Return the email as a discriminator on POST /login requests
-Rack::Attack.throttle('logins/email', limit: 6, period: 60.seconds) do |req|
+Rack::Attack.throttle('logins/email', limit: 6, period: 60) do |req|
   req.params['email'] if req.path == '/login' && req.post?
 end
 
@@ -209,7 +209,7 @@ Rack::Attack.track("special_agent") do |req|
 end
 
 # Supports optional limit and period, triggers the notification only when the limit is reached.
-Rack::Attack.track("special_agent", limit: 6, period: 60.seconds) do |req|
+Rack::Attack.track("special_agent", limit: 6, period: 60) do |req|
   req.user_agent == "SpecialAgent"
 end
 


### PR DESCRIPTION
So that users pasting these examples don't get

```
undefined method `seconds' for 5:Integer
```

if they're not using activesupport in their apps