### PR TITLE
fix rubocop complains about initializer file name (use snake_case)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Or for Rackup files:
 use Rack::Attack
 ```
 
-Add a `rack-attack.rb` file to `config/initializers/`:
+Add a `rack_attack.rb` file to `config/initializers/`:
 ```ruby
-# In config/initializers/rack-attack.rb
+# In config/initializers/rack_attack.rb
 class Rack::Attack
   # your custom configuration...
 end


### PR DESCRIPTION
#### What's this PR do?

- use snake_case for initializer file name.
- surpress rubocop complains that use snake case for initializer file name.

#### Where should the reviewer start?

README.md

#### Any background context you want to provide?

config/initalizers/rack-attack.rb is recommended in README.md

#### What are the relevant tickets?

[RuboCop complains about initializer file name · Issue #275 · kickstarter/rack-attack](https://github.com/kickstarter/rack-attack/issues/275)