### PR TITLE
Fix several code style offenses

### DIFF
--- a/lib/rack/attack/allow2ban.rb
+++ b/lib/rack/attack/allow2ban.rb
@@ -3,6 +3,7 @@ module Rack
     class Allow2Ban < Fail2Ban
       class << self
         protected
+
         def key_prefix
           'allow2ban'
         end
@@ -11,9 +12,7 @@ module Rack
         # (blocking the request) if they have tripped the limit.
         def fail!(discriminator, bantime, findtime, maxretry)
           count = cache.count("#{key_prefix}:count:#{discriminator}", findtime)
-          if count >= maxretry
-            ban!(discriminator, bantime)
-          end
+          ban!(discriminator, bantime) if count >= maxretry
           # we may not block them this time, but they're banned for next time
           false
         end

--- a/lib/rack/attack/blocklist.rb
+++ b/lib/rack/attack/blocklist.rb
@@ -5,7 +5,6 @@ module Rack
         super
         @type = :blocklist
       end
-
     end
   end
 end

--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -1,7 +1,6 @@
 module Rack
   class Attack
     class Cache
-
       attr_accessor :prefix
 
       def initialize
@@ -24,11 +23,11 @@ module Rack
       end
 
       def write(unprefixed_key, value, expires_in)
-        store.write("#{prefix}:#{unprefixed_key}", value, :expires_in => expires_in)
+        store.write("#{prefix}:#{unprefixed_key}", value, expires_in: expires_in)
       end
 
       def reset_count(unprefixed_key, period)
-        key, _ = key_and_expiry(unprefixed_key, period)
+        key, _expires_in = key_and_expiry(unprefixed_key, period)
         store.delete(key)
       end
 

--- a/lib/rack/attack/check.rb
+++ b/lib/rack/attack/check.rb
@@ -2,22 +2,22 @@ module Rack
   class Attack
     class Check
       attr_reader :name, :block, :type
+
       def initialize(name, options = {}, block)
-        @name, @block = name, block
+        @name = name
+        @block = block
         @type = options.fetch(:type, nil)
       end
 
       def [](req)
-        block[req].tap {|match|
+        block[req].tap do |match|
           if match
             req.env["rack.attack.matched"] = name
             req.env["rack.attack.match_type"] = type
             Rack::Attack.instrument(req)
           end
-        }
+        end
       end
-
     end
   end
 end
-

--- a/lib/rack/attack/fail2ban.rb
+++ b/lib/rack/attack/fail2ban.rb
@@ -3,9 +3,9 @@ module Rack
     class Fail2Ban
       class << self
         def filter(discriminator, options)
-          bantime   = options[:bantime]   or raise ArgumentError, "Must pass bantime option"
-          findtime  = options[:findtime]  or raise ArgumentError, "Must pass findtime option"
-          maxretry  = options[:maxretry]  or raise ArgumentError, "Must pass maxretry option"
+          bantime   = options[:bantime]   || raise(ArgumentError, "Must pass bantime option")
+          findtime  = options[:findtime]  || raise(ArgumentError, "Must pass findtime option")
+          maxretry  = options[:maxretry]  || raise(ArgumentError, "Must pass maxretry option")
 
           if banned?(discriminator)
             # Return true for blocklist
@@ -16,7 +16,7 @@ module Rack
         end
 
         def reset(discriminator, options)
-          findtime = options[:findtime] or raise ArgumentError, "Must pass findtime option"
+          findtime = options[:findtime] || raise(ArgumentError, "Must pass findtime option")
           cache.reset_count("#{key_prefix}:count:#{discriminator}", findtime)
           # Clear ban flag just in case it's there
           cache.delete("#{key_prefix}:ban:#{discriminator}")
@@ -27,21 +27,20 @@ module Rack
         end
 
         protected
+
         def key_prefix
           'fail2ban'
         end
 
         def fail!(discriminator, bantime, findtime, maxretry)
           count = cache.count("#{key_prefix}:count:#{discriminator}", findtime)
-          if count >= maxretry
-            ban!(discriminator, bantime)
-          end
+          ban!(discriminator, bantime) if count >= maxretry
 
           true
         end
 
-
         private
+
         def ban!(discriminator, bantime)
           cache.write("#{key_prefix}:ban:#{discriminator}", 1, bantime)
         end

--- a/lib/rack/attack/safelist.rb
+++ b/lib/rack/attack/safelist.rb
@@ -5,7 +5,6 @@ module Rack
         super
         @type = :safelist
       end
-
     end
   end
 end

--- a/lib/rack/attack/store_proxy.rb
+++ b/lib/rack/attack/store_proxy.rb
@@ -12,8 +12,8 @@ module Rack
         klass ? klass.new(client) : client
       end
 
-
       private
+
       def self.unwrap_active_support_stores(store)
         # ActiveSupport::Cache::RedisStore doesn't expose any way to set an expiry,
         # so use the raw Redis::Store instead.

--- a/lib/rack/attack/store_proxy/dalli_proxy.rb
+++ b/lib/rack/attack/store_proxy/dalli_proxy.rb
@@ -28,14 +28,14 @@ module Rack
         rescue Dalli::DalliError
         end
 
-        def write(key, value, options={})
+        def write(key, value, options = {})
           with do |client|
             client.set(key, value, options.fetch(:expires_in, 0), raw: true)
           end
         rescue Dalli::DalliError
         end
 
-        def increment(key, amount, options={})
+        def increment(key, amount, options = {})
           with do |client|
             client.incr(key, amount, options.fetch(:expires_in, 0), amount)
           end
@@ -52,13 +52,11 @@ module Rack
         private
 
         def stub_with_if_missing
-          unless __getobj__.respond_to?(:with)
-            class << self
-              def with; yield __getobj__; end
-            end
+          return if __getobj__.respond_to?(:with)
+          class << self
+            def with; yield __getobj__; end
           end
         end
-
       end
     end
   end

--- a/lib/rack/attack/store_proxy/mem_cache_proxy.rb
+++ b/lib/rack/attack/store_proxy/mem_cache_proxy.rb
@@ -17,18 +17,18 @@ module Rack
           rescue MemCache::MemCacheError
         end
 
-        def write(key, value, options={})
+        def write(key, value, options = {})
           # Third argument: writing raw value
           set(key, value, options.fetch(:expires_in, 0), true)
         rescue MemCache::MemCacheError
         end
 
-        def increment(key, amount, options={})
+        def increment(key, amount, _options = {})
           incr(key, amount)
         rescue MemCache::MemCacheError
         end
 
-        def delete(key, options={})
+        def delete(key, _options = {})
           with do |client|
             client.delete(key)
           end
@@ -38,13 +38,11 @@ module Rack
         private
 
         def stub_with_if_missing
-          unless __getobj__.respond_to?(:with)
-            class << self
-              def with; yield __getobj__; end
-            end
+          return if __getobj__.respond_to?(:with)
+          class << self
+            def with; yield __getobj__; end
           end
         end
-
       end
     end
   end

--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -24,7 +24,7 @@ module Rack
         rescue Redis::BaseError
         end
 
-        def write(key, value, options={})
+        def write(key, value, options = {})
           if (expires_in = options[:expires_in])
             setex(key, expires_in, value, raw: true)
           else
@@ -33,7 +33,7 @@ module Rack
         rescue Redis::BaseError
         end
 
-        def increment(key, amount, options={})
+        def increment(key, amount, options = {})
           count = nil
 
           pipelined do
@@ -45,7 +45,7 @@ module Rack
         rescue Redis::BaseError
         end
 
-        def delete(key, options={})
+        def delete(key, _options = {})
           del(key)
         rescue Redis::BaseError
         end

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -1,13 +1,15 @@
 module Rack
   class Attack
     class Throttle
-      MANDATORY_OPTIONS = [:limit, :period].freeze
+      MANDATORY_OPTIONS = %i[limit period].freeze
 
       attr_reader :name, :limit, :period, :block, :type
+
       def initialize(name, options, block)
-        @name, @block = name, block
+        @name = name
+        @block = block
         MANDATORY_OPTIONS.each do |opt|
-          raise ArgumentError.new("Must pass #{opt.inspect} option") unless options[opt]
+          raise ArgumentError, "Must pass #{opt.inspect} option" unless options[opt]
         end
         @limit  = options[:limit]
         @period = options[:period].respond_to?(:call) ? options[:period] : options[:period].to_i
@@ -28,9 +30,9 @@ module Rack
         count          = cache.count(key, current_period)
 
         data = {
-          :count => count,
-          :period => current_period,
-          :limit => current_limit
+          count: count,
+          period: current_period,
+          limit: current_limit
         }
         (req.env['rack.attack.throttle_data'] ||= {})[name] = data
 

--- a/lib/rack/attack/track.rb
+++ b/lib/rack/attack/track.rb
@@ -8,11 +8,11 @@ module Rack
       def initialize(name, options = {}, block)
         options[:type] = :track
 
-        if options[:limit] && options[:period]
-          @filter = Throttle.new(name, options, block)
-        else
-          @filter = Check.new(name, options, block)
-        end
+        @filter = if options[:limit] && options[:period]
+                    Throttle.new(name, options, block)
+                  else
+                    Check.new(name, options, block)
+                  end
       end
 
       def_delegator :@filter, :[]


### PR DESCRIPTION
As @ktheory suggested in #219, this is an attempt keep the project up to date with the [community style guide](https://github.com/bbatsov/ruby-style-guide).

This is a good space to discuss what to adopt and what not to adopt from the guide. Should we set some guidelines or just use Rubocop? Or just ignore style all together?

I feel like following some kind of guideline helps the code be more consistent and less of a hassle to understand.