### PR TITLE
Mention 'match_discriminator' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ Rack::Attack.throttled_response = lambda do |env|
   # NB: you have access to the name and other data about the matched throttle
   #  env['rack.attack.matched'],
   #  env['rack.attack.match_type'],
-  #  env['rack.attack.match_data']
+  #  env['rack.attack.match_data'],
+  #  env['rack.attack.match_discriminator']
 
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 429 for throttling by default


### PR DESCRIPTION
Thanks for your work on this gem! I have a small change to propose to the README. I was looking to return the cache key in a throttle response, and noticed that the `rack.attack.match_discriminator` environment key provides this. Thought it would be useful to mention as another example of what you can return in a throttle response.