### PR TITLE
Update all non-secure HTTP URLs to HTTPS

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -18,4 +18,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 :hand: :page_with_curl:
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org) (v1.0.0), available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) (v1.0.0), available at [https://www.contributor-covenant.org/version/1/0/0/](https://www.contributor-covenant.org/version/1/0/0/)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Protect your Rails and Rack apps from bad clients. Rack::Attack lets you easily decide when to *allow*, *block* and *throttle* based on properties of the request.
 
-See the [Backing & Hacking blog post](http://www.kickstarter.com/backing-and-hacking/rack-attack-protection-from-abusive-clients) introducing Rack::Attack.
+See the [Backing & Hacking blog post](https://www.kickstarter.com/backing-and-hacking/rack-attack-protection-from-abusive-clients) introducing Rack::Attack.
 
-[![Gem Version](https://badge.fury.io/rb/rack-attack.svg)](http://badge.fury.io/rb/rack-attack)
+[![Gem Version](https://badge.fury.io/rb/rack-attack.svg)](https://badge.fury.io/rb/rack-attack)
 [![Build Status](https://travis-ci.org/kickstarter/rack-attack.svg?branch=master)](https://travis-ci.org/kickstarter/rack-attack)
 [![Code Climate](https://codeclimate.com/github/kickstarter/rack-attack.svg)](https://codeclimate.com/github/kickstarter/rack-attack)
 
@@ -155,8 +155,8 @@ end
 #### Fail2Ban
 
 `Fail2Ban.filter` can be used within a blocklist to block all requests from misbehaving clients.
-This pattern is inspired by [fail2ban](http://www.fail2ban.org/wiki/index.php/Main_Page).
-See the [fail2ban documentation](http://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jail_Options) for more details on
+This pattern is inspired by [fail2ban](https://www.fail2ban.org/wiki/index.php/Main_Page).
+See the [fail2ban documentation](https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Jail_Options) for more details on
 how the parameters work.  For multiple filters, be sure to put each filter in a separate blocklist and use a unique discriminator for each fail2ban filter.
 
 Fail2ban state is stored in a [configurable cache](#cache-store-configuration) (which defaults to `Rails.cache` if present).
@@ -272,7 +272,7 @@ Note that `Rack::Attack.cache` is only used for throttling, allow2ban and fail2b
 
 ## Customizing responses
 
-Customize the response of blocklisted and throttled requests using an object that adheres to the [Rack app interface](http://rack.rubyforge.org/doc/SPEC.html).
+Customize the response of blocklisted and throttled requests using an object that adheres to the [Rack app interface](http://www.rubydoc.info/github/rack/rack/file/SPEC).
 
 ```ruby
 Rack::Attack.blocklisted_response = lambda do |env|
@@ -388,7 +388,7 @@ so try to keep the number of throttle checks per request low.
 If a request is blocklisted or throttled, the response is a very simple Rack response.
 A single typical ruby web server thread can block several hundred requests per second.
 
-Rack::Attack complements tools like `iptables` and nginx's [limit_conn_zone module](http://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone).
+Rack::Attack complements tools like `iptables` and nginx's [limit_conn_zone module](https://nginx.org/en/docs/http/ngx_http_limit_conn_module.html#limit_conn_zone).
 
 ## Motivation
 
@@ -408,7 +408,7 @@ adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ### Testing pull requests
 
-To run the minitest test suite, you will need both [Redis](http://redis.io/) and
+To run the minitest test suite, you will need both [Redis](https://redis.io/) and
 [Memcached](https://memcached.org/) running locally and bound to IP `127.0.0.1` on
 default ports (`6379` for Redis, and `11211` for Memcached) and able to be
 accessed without authentication.
@@ -434,4 +434,4 @@ New releases of Rack::Attack are announced on
 
 Copyright Kickstarter, PBC.
 
-Released under an [MIT License](http://opensource.org/licenses/MIT).
+Released under an [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -43,7 +43,7 @@ module Rack
 
       def key_and_expiry(unprefixed_key, period)
         epoch_time = Time.now.to_i
-        # Add 1 to expires_in to avoid timing error: http://git.io/i1PHXA
+        # Add 1 to expires_in to avoid timing error: https://git.io/i1PHXA
         expires_in = (period - (epoch_time % period) + 1).to_i
         ["#{prefix}:#{(epoch_time / period).to_i}:#{unprefixed_key}", expires_in]
       end

--- a/lib/rack/attack/path_normalizer.rb
+++ b/lib/rack/attack/path_normalizer.rb
@@ -2,7 +2,7 @@ class Rack::Attack
 
   # When using Rack::Attack with a Rails app, developers expect the request path
   # to be normalized. In particular, trailing slashes are stripped.
-  # (See http://git.io/v0rrR for implementation.)
+  # (See https://git.io/v0rrR for implementation.)
   #
   # Look for an ActionDispatch utility class that Rails folks would expect
   # to normalize request paths. If unavailable, use a fallback class that

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = "aaron@ktheory.com"
 
   s.files = Dir.glob("{bin,lib}/**/*") + %w(Rakefile README.md)
-  s.homepage = 'http://github.com/kickstarter/rack-attack'
+  s.homepage = 'https://github.com/kickstarter/rack-attack'
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.summary = %q{Block & throttle abusive requests}


### PR DESCRIPTION
All non-secure HTTP URLs have been updated to use HTTPS (if available).

These services still don't support HTTPS at this time:

- `http://api.rubyonrails.org`
- `http://guides.rubyonrails.org`
- `http://librelist.com`
- `http://www.rubydoc.info`

Closes https://github.com/kickstarter/rack-attack/issues/327