### PR TITLE
Avoid user confusion by renaming .clear! to .clear_configuration

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -120,10 +120,15 @@ class Rack::Attack
       @cache ||= Cache.new
     end
 
-    def clear!
+    def clear_configuration
       @safelists, @blocklists, @throttles, @tracks = {}, {}, {}, {}
       @ip_blocklists = []
       @ip_safelists = []
+    end
+
+    def clear!
+      warn "[DEPRECATION] Rack::Attack.clear! is deprecated. Please use Rack::Attack.clear_configuration instead"
+      clear_configuration
     end
 
     def blacklisted_response=(res)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ class MiniTest::Spec
   end
 
   after do
-    Rack::Attack.clear!
+    Rack::Attack.clear_configuration
     Rack::Attack.instance_variable_set(:@cache, nil)
 
     Rack::Attack.throttled_response = @_original_throttled_response


### PR DESCRIPTION
Avoid confusion like in https://github.com/kickstarter/rack-attack/issues/208#issue-190251995