### PR TITLE
Add SemVer compatibility badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Protect your Rails and Rack apps from bad clients. Rack::Attack lets you easily 
 See the [Backing & Hacking blog post](https://www.kickstarter.com/backing-and-hacking/rack-attack-protection-from-abusive-clients) introducing Rack::Attack.
 
 [![Gem Version](https://badge.fury.io/rb/rack-attack.svg)](https://badge.fury.io/rb/rack-attack)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rack-attack&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rack-attack&package-manager=bundler&version-scheme=semver)
 [![Build Status](https://travis-ci.org/kickstarter/rack-attack.svg?branch=master)](https://travis-ci.org/kickstarter/rack-attack)
 [![Code Climate](https://codeclimate.com/github/kickstarter/rack-attack.svg)](https://codeclimate.com/github/kickstarter/rack-attack)
 


### PR DESCRIPTION
First up, thanks for Rack::Attack. I use it in almost all my projects and love it.

This PR adds a SemVer compatibility badge that displays the percentage of CI runs that pass when updating Rack::Attack between SemVer compatible versions. Data comes from Dependabot (disclosure: I built it). The idea is to make it clear to people to know they can specify `~> 5.0` in their Gemfile, based on how well you guys have always observed SemVer.

Here's what the badge looks like:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=rack-attack&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=rack-attack&package-manager=bundler&version-scheme=semver)