### PR TITLE
Introduce a Redis proxy compatible with ~>redis-3.0.

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -18,6 +18,7 @@ class Rack::Attack
   autoload :DalliProxy,      'rack/attack/store_proxy/dalli_proxy'
   autoload :MemCacheProxy,   'rack/attack/store_proxy/mem_cache_proxy'
   autoload :RedisStoreProxy, 'rack/attack/store_proxy/redis_store_proxy'
+  autoload :RedisProxy,      'rack/attack/store_proxy/redis_proxy'
   autoload :Fail2Ban,        'rack/attack/fail2ban'
   autoload :Allow2Ban,       'rack/attack/allow2ban'
 

--- a/lib/rack/attack/store_proxy.rb
+++ b/lib/rack/attack/store_proxy.rb
@@ -1,7 +1,7 @@
 module Rack
   class Attack
     module StoreProxy
-      PROXIES = [DalliProxy, MemCacheProxy, RedisStoreProxy].freeze
+      PROXIES = [DalliProxy, MemCacheProxy, RedisStoreProxy, RedisProxy].freeze
 
       ACTIVE_SUPPORT_WRAPPER_CLASSES = Set.new(['ActiveSupport::Cache::MemCacheStore', 'ActiveSupport::Cache::RedisStore']).freeze
       ACTIVE_SUPPORT_CLIENTS = Set.new(['Redis::Store', 'Dalli::Client', 'MemCache']).freeze

--- a/lib/rack/attack/store_proxy/redis_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_proxy.rb
@@ -1,0 +1,29 @@
+require 'delegate'
+
+module Rack
+  class Attack
+    module StoreProxy
+      class RedisProxy < RedisStoreProxy
+        def self.handle?(store)
+          defined?(::Redis) && store.is_a?(::Redis)
+        end
+
+        def initialize(store)
+          super(store)
+        end
+
+        def get(key, _options = {})
+          super(key)
+        end
+
+        def setex(key, ttl, value, _options = {})
+          super(key, ttl, value)
+        end
+
+        def setnx(key, value, _options = {})
+          super(key, value)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #213, #136, #190.

Root cause analysis is contained in #213.

In this new `RedisProxy` we just throw away the `redis-store` extensions to the plain `redis` interface. We have been using a similar approach in production for almost a year without issues. That being said, we only use the rate-throttling (and not the fail2ban) behaviour of rack-attack.

Let me know if you require further information or would like to make any amendments to the pull request.