### PR TITLE
Fix usage of RedisCacheStore for rails 5.2.0

### DIFF
--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -10,11 +10,13 @@ module Rack
 
         def increment(name, amount, options = {})
           # Redis doesn't check expiration on the INCRBY command. See https://redis.io/commands/expire
-          count = redis.pipelined do
-            redis.incrby(name, amount)
-            redis.expire(name, options[:expires_in]) if options[:expires_in]
+          redis.with do |r|
+            count = r.pipelined do
+              r.incrby(name, amount)
+              r.expire(name, options[:expires_in]) if options[:expires_in]
+            end
+            count.first
           end
-          count.first
         end
 
         def read(name, options = {})


### PR DESCRIPTION
Fix https://github.com/kickstarter/rack-attack/issues/352. 

`Redis` and `Redis::Distributed` patched by rails to support `with` https://github.com/rails/rails/blob/b7760eb75a9dd002260a361119aea0b255e1f573/activesupport/lib/active_support/cache/redis_cache_store.rb#L23-L30 