### PR TITLE
Make test run output a bit more clear by collapsing runs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,8 @@ namespace :test do
   end
 end
 
-desc 'Run tests'
-task :test => %w[test:units test:integration test:acceptance]
+Rake::TestTask.new(:test) do |t|
+  t.pattern = "spec/**/*_spec.rb"
+end
 
 task :default => [:rubocop, :test]


### PR DESCRIPTION
__Before__:

```
$ bundle exec rake test
Run options: --seed 27993

# Running:

......................................................................

Fabulous run in 0.081738s, 856.3938 runs/s, 1052.1409 assertions/s.

70 runs, 86 assertions, 0 failures, 0 errors, 0 skips
Run options: --seed 51733

# Running:



Fabulous run in 0.000513s, 0.0000 runs/s, 0.0000 assertions/s.

0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
Run options: --seed 12241

# Running:

...................................................................

Fabulous run in 2.155369s, 31.0852 runs/s, 82.1205 assertions/s.

67 runs, 177 assertions, 0 failures, 0 errors, 0 skips
```

__After__:

```
$ bundle exec rake test
Run options: --seed 7980

# Running:

.........................................................................................................................................

Fabulous run in 2.223840s, 61.6052 runs/s, 118.2639 assertions/s.

137 runs, 263 assertions, 0 failures, 0 errors, 0 skips
```