### PR TITLE
Fix usage with connection-pooled MemCacheStore

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -19,6 +19,7 @@ class Rack::Attack
   autoload :StoreProxy,           'rack/attack/store_proxy'
   autoload :DalliProxy,           'rack/attack/store_proxy/dalli_proxy'
   autoload :MemCacheProxy,        'rack/attack/store_proxy/mem_cache_proxy'
+  autoload :MemCacheStoreProxy,   'rack/attack/store_proxy/mem_cache_store_proxy'
   autoload :RedisProxy,           'rack/attack/store_proxy/redis_proxy'
   autoload :RedisStoreProxy,      'rack/attack/store_proxy/redis_store_proxy'
   autoload :RedisCacheStoreProxy, 'rack/attack/store_proxy/redis_cache_store_proxy'

--- a/lib/rack/attack/store_proxy/mem_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/mem_cache_store_proxy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module Rack
+  class Attack
+    module StoreProxy
+      class MemCacheStoreProxy < SimpleDelegator
+        def self.handle?(store)
+          defined?(::Dalli) && defined?(::ActiveSupport::Cache::MemCacheStore) && store.is_a?(::ActiveSupport::Cache::MemCacheStore)
+        end
+
+        def write(name, value, options = {})
+          super(name, value, options.merge!(raw: true))
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/stores/active_support_mem_cache_store_pooled_spec.rb
+++ b/spec/acceptance/stores/active_support_mem_cache_store_pooled_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+if defined?(::ConnectionPool) && defined?(::Dalli)
+  require_relative "../../support/cache_store_helper"
+  require "timecop"
+
+  describe "ActiveSupport::Cache::MemCacheStore (pooled) as a cache backend" do
+    before do
+      Rack::Attack.cache.store = ActiveSupport::Cache::MemCacheStore.new(pool_size: 2)
+    end
+
+    after do
+      Rack::Attack.cache.store.clear
+    end
+
+    it_works_for_cache_backed_features(fetch_from_store: ->(key) {
+      Rack::Attack.cache.store.read(key)
+    })
+  end
+end

--- a/spec/acceptance/stores/active_support_mem_cache_store_spec.rb
+++ b/spec/acceptance/stores/active_support_mem_cache_store_spec.rb
@@ -12,9 +12,9 @@ if defined?(::Dalli)
     end
 
     after do
-      Rack::Attack.cache.store.flush_all
+      Rack::Attack.cache.store.clear
     end
 
-    it_works_for_cache_backed_features(fetch_from_store: ->(key) { Rack::Attack.cache.store.get(key) })
+    it_works_for_cache_backed_features(fetch_from_store: ->(key) { Rack::Attack.cache.store.read(key) })
   end
 end


### PR DESCRIPTION
We recently added `pool_size` to our Rails cache options:
```
config.cache_store = :mem_cache_store, *memcache_hosts, pool_size: 5
```

and discovered that Rack::Attack was no longer throttling.  (StoreProxy.build wasn't detecting the store as proxyable, so would return the bare ActiveSupport::Cache::MemCacheStore instance rather than a DalliProxy)

This PR refactors the ConnectionPool handling into a PoolProxy superclass, and makes StoreProxy.build aware of ConnectionPools.

WDYT?