### PR TITLE
Prefer to not use X- style headers for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ end
 While Rack::Attack's primary focus is minimizing harm from abusive clients, it
 can also be used to return rate limit data that's helpful for well-behaved clients.
 
-Here's an example response that includes conventional `X-RateLimit-*` headers:
+Here's an example response that includes conventional `RateLimit-*` headers:
 
 ```ruby
 Rack::Attack.throttled_response = lambda do |env|
@@ -308,9 +308,9 @@ Rack::Attack.throttled_response = lambda do |env|
   now = match_data[:epoch_time]
 
   headers = {
-    'X-RateLimit-Limit' => match_data[:limit].to_s,
-    'X-RateLimit-Remaining' => '0',
-    'X-RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
+    'RateLimit-Limit' => match_data[:limit].to_s,
+    'RateLimit-Remaining' => '0',
+    'RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
   }
 
   [ 429, headers, ["Throttled\n"]]

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Rack::Attack.throttled_response = lambda do |env|
 end
 ```
 
-### X-RateLimit headers for well-behaved clients
+### RateLimit headers for well-behaved clients
 
 While Rack::Attack's primary focus is minimizing harm from abusive clients, it
 can also be used to return rate limit data that's helpful for well-behaved clients.


### PR DESCRIPTION
The IETF decided the X- style custom headers have caused more headache than the value: https://tools.ietf.org/html/rfc6648 so this tool (which is very popular and much loved) shouldn't suggest using an old style.