### PR TITLE
Remove unnecessary wrapping of ActiveSupport::Cache::RedisCacheStore#read

### DIFF
--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -24,10 +24,6 @@ module Rack
           end
         end
 
-        def read(name, options = {})
-          super(name, options.merge!(raw: true))
-        end
-
         def write(name, value, options = {})
           super(name, value, options.merge!(raw: true))
         end


### PR DESCRIPTION
`raw: true` isn't doing anything special for `read`, only for `write`