### PR TITLE
Feature proposal: Request instead of Env in callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,18 +313,18 @@ Note that `Rack::Attack.cache` is only used for throttling, allow2ban and fail2b
 Customize the response of blocklisted and throttled requests using an object that adheres to the [Rack app interface](http://www.rubydoc.info/github/rack/rack/file/SPEC).
 
 ```ruby
-Rack::Attack.blocklisted_response = lambda do |env|
+Rack::Attack.blocklisted_callback = lambda do |request|
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 403 for blocklists by default
   [ 503, {}, ['Blocked']]
 end
 
-Rack::Attack.throttled_response = lambda do |env|
+Rack::Attack.throttled_callback = lambda do |request|
   # NB: you have access to the name and other data about the matched throttle
-  #  env['rack.attack.matched'],
-  #  env['rack.attack.match_type'],
-  #  env['rack.attack.match_data'],
-  #  env['rack.attack.match_discriminator']
+  #  request.env['rack.attack.matched'],
+  #  request.env['rack.attack.match_type'],
+  #  request.env['rack.attack.match_data'],
+  #  request.env['rack.attack.match_discriminator']
 
   # Using 503 because it may make attacker think that they have successfully
   # DOSed the site. Rack::Attack returns 429 for throttling by default
@@ -411,9 +411,10 @@ def call(env)
   if safelisted?(req)
     @app.call(env)
   elsif blocklisted?(req)
-    self.class.blocklisted_response.call(env)
+    self.class.blocklisted_callback.call(req)
   elsif throttled?(req)
     self.class.throttled_response.call(env)
+    self.class.throttled_callback.call(req)
   else
     tracked?(req)
     @app.call(env)

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,10 @@ Install dependencies by running
 
     $ bundle install
 
+Install test dependencies by running:
+
+    $ bundle exec appraisal install
+
 Then run the test suite by running
 
     $ bundle exec appraisal rake test

--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -66,6 +66,10 @@ module Rack
         :safelist_ip,
         :throttle,
         :track,
+        :throttled_callback,
+        :throttled_callback=,
+        :blocklisted_callback,
+        :blocklisted_callback=,
         :blocklisted_response,
         :blocklisted_response=,
         :throttled_response,
@@ -105,9 +109,13 @@ module Rack
       if configuration.safelisted?(request)
         @app.call(env)
       elsif configuration.blocklisted?(request)
-        configuration.blocklisted_response.call(env)
+        # Deprecated: Keeping blocklisted_response for backwards compatibility
+        configuration.blocklisted_response ? configuration.blocklisted_response.call(env) :
+            configuration.blocklisted_callback.call(request)
       elsif configuration.throttled?(request)
-        configuration.throttled_response.call(env)
+        # Deprecated: Keeping throttled_response for backwards compatibility
+        configuration.throttled_response ? configuration.throttled_response.call(env) :
+            configuration.throttled_callback.call(request)
       else
         configuration.tracked?(request)
         @app.call(env)

--- a/spec/acceptance/customizing_blocked_response_spec.rb
+++ b/spec/acceptance/customizing_blocked_response_spec.rb
@@ -14,7 +14,7 @@ describe "Customizing block responses" do
 
     assert_equal 403, last_response.status
 
-    Rack::Attack.blocklisted_response = lambda do |_env|
+    Rack::Attack.blocklisted_callback = lambda do |_req|
       [503, {}, ["Blocked"]]
     end
 
@@ -28,9 +28,9 @@ describe "Customizing block responses" do
     matched = nil
     match_type = nil
 
-    Rack::Attack.blocklisted_response = lambda do |env|
-      matched = env['rack.attack.matched']
-      match_type = env['rack.attack.match_type']
+     Rack::Attack.blocklisted_callback = lambda do |req|
+      matched = req.env['rack.attack.matched']
+      match_type = req.env['rack.attack.match_type']
 
       [503, {}, ["Blocked"]]
     end

--- a/spec/acceptance/customizing_blocked_response_spec.rb
+++ b/spec/acceptance/customizing_blocked_response_spec.rb
@@ -28,7 +28,7 @@ describe "Customizing block responses" do
     matched = nil
     match_type = nil
 
-     Rack::Attack.blocklisted_callback = lambda do |req|
+    Rack::Attack.blocklisted_callback = lambda do |req|
       matched = req.env['rack.attack.matched']
       match_type = req.env['rack.attack.match_type']
 

--- a/spec/acceptance/customizing_blocked_response_spec.rb
+++ b/spec/acceptance/customizing_blocked_response_spec.rb
@@ -40,4 +40,19 @@ describe "Customizing block responses" do
     assert_equal "block 1.2.3.4", matched
     assert_equal :blocklist, match_type
   end
+
+  it "supports old style" do
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 403, last_response.status
+
+    Rack::Attack.blocklisted_response = lambda do |_env|
+      [503, {}, ["Blocked"]]
+    end
+
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 503, last_response.status
+    assert_equal "Blocked", last_response.body
+  end
 end

--- a/spec/acceptance/customizing_throttled_response_spec.rb
+++ b/spec/acceptance/customizing_throttled_response_spec.rb
@@ -58,4 +58,23 @@ describe "Customizing throttled response" do
     get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
     assert_equal 3, match_data[:count]
   end
+
+  it "supports old style" do
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 200, last_response.status
+
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 429, last_response.status
+
+    Rack::Attack.throttled_response = lambda do |_req|
+      [503, {}, ["Throttled"]]
+    end
+
+    get "/", {}, "REMOTE_ADDR" => "1.2.3.4"
+
+    assert_equal 503, last_response.status
+    assert_equal "Throttled", last_response.body
+  end
 end

--- a/spec/acceptance/customizing_throttled_response_spec.rb
+++ b/spec/acceptance/customizing_throttled_response_spec.rb
@@ -20,7 +20,7 @@ describe "Customizing throttled response" do
 
     assert_equal 429, last_response.status
 
-    Rack::Attack.throttled_response = lambda do |_env|
+    Rack::Attack.throttled_callback = lambda do |_req|
       [503, {}, ["Throttled"]]
     end
 
@@ -36,11 +36,11 @@ describe "Customizing throttled response" do
     match_data = nil
     match_discriminator = nil
 
-    Rack::Attack.throttled_response = lambda do |env|
-      matched = env['rack.attack.matched']
-      match_type = env['rack.attack.match_type']
-      match_data = env['rack.attack.match_data']
-      match_discriminator = env['rack.attack.match_discriminator']
+    Rack::Attack.throttled_callback = lambda do |req|
+      matched = req.env['rack.attack.matched']
+      match_type = req.env['rack.attack.match_type']
+      match_data = req.env['rack.attack.match_data']
+      match_discriminator = req.env['rack.attack.match_discriminator']
 
       [429, {}, ["Throttled"]]
     end

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -64,15 +64,15 @@ describe 'Rack::Attack' do
       end
     end
 
-    describe '#blocklisted_response' do
+    describe '#blocklisted_callback' do
       it 'should exist' do
-        _(Rack::Attack.blocklisted_response).must_respond_to :call
+        _(Rack::Attack.blocklisted_callback).must_respond_to :call
       end
     end
 
-    describe '#throttled_response' do
+    describe '#throttled_callback' do
       it 'should exist' do
-        _(Rack::Attack.throttled_response).must_respond_to :call
+        _(Rack::Attack.throttled_callback).must_respond_to :call
       end
     end
   end


### PR DESCRIPTION
Hello, I would like to propose an improvement that our company uses internally as a monkey-patch, to which I've added the tests, backward compatibility and proper styling for community use.

In short, when a request is throttled or blocklisted, it's much more convenient to have access to a complete Rack request object instead of just environment hash - for example, for the reporting purposes.

This request contains the following:
1. Adds new variables for the callbacks with better naming, which now receive Rack request instead of an environment object.
2. It retains backward compatibility with the previous implementation.
3. Updates to documentation to match the proposed interface.
4. Small improvement for development docs.

Please let me know what you think.