### PR TITLE
Allow to reset state

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -14,6 +14,7 @@ module Rack
     class Error < StandardError; end
     class MisconfiguredStoreError < Error; end
     class MissingStoreError < Error; end
+    class IncompatibleStoreError < Error; end
 
     autoload :Check,                'rack/attack/check'
     autoload :Throttle,             'rack/attack/throttle'
@@ -51,6 +52,10 @@ module Rack
       def clear!
         warn "[DEPRECATION] Rack::Attack.clear! is deprecated. Please use Rack::Attack.clear_configuration instead"
         @configuration.clear_configuration
+      end
+
+      def reset!
+        cache.reset!
       end
 
       extend Forwardable

--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -41,6 +41,17 @@ module Rack
         store.delete("#{prefix}:#{unprefixed_key}")
       end
 
+      def reset!
+        if store.respond_to?(:delete_matched)
+          store.delete_matched("#{prefix}*")
+        else
+          raise(
+            Rack::Attack::IncompatibleStoreError,
+            "Configured store #{store.class.name} doesn't respond to #delete_matched method"
+          )
+        end
+      end
+
       private
 
       def key_and_expiry(unprefixed_key, period)

--- a/lib/rack/attack/store_proxy/redis_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_proxy.rb
@@ -43,6 +43,19 @@ module Rack
           rescuing { del(key) }
         end
 
+        def delete_matched(matcher, _options = nil)
+          cursor = "0"
+
+          rescuing do
+            # Fetch keys in batches using SCAN to avoid blocking the Redis server.
+            loop do
+              cursor, keys = scan(cursor, match: matcher, count: 1000)
+              del(*keys) unless keys.empty?
+              break if cursor == "0"
+            end
+          end
+        end
+
         private
 
         def rescuing

--- a/spec/rack_attack_spec.rb
+++ b/spec/rack_attack_spec.rb
@@ -99,4 +99,26 @@ describe 'Rack::Attack' do
       end
     end
   end
+
+  describe 'reset!' do
+    it 'raises an error when is not supported by cache store' do
+      Rack::Attack.cache.store = Class.new
+      assert_raises(Rack::Attack::IncompatibleStoreError) do
+        Rack::Attack.reset!
+      end
+    end
+
+    if defined?(Redis)
+      it 'should delete rack attack keys' do
+        redis = Redis.new
+        redis.set('key', 'value')
+        redis.set("#{Rack::Attack.cache.prefix}::key", 'value')
+        Rack::Attack.cache.store = redis
+        Rack::Attack.reset!
+
+        _(redis.get('key')).must_equal 'value'
+        _(redis.get("#{Rack::Attack.cache.prefix}::key")).must_be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/kickstarter/rack-attack/issues/249#issuecomment-539029878

I can think of 2 (not functionally equal) implementations:
1. `Rack::Attack.reset!` which really resets (deletes) specific keys in cache store and can be used for testing as well as production. But, while this can be implemented for most of cache stores (using https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-delete_matched), this is not (and can't be) supported by memcache (the second most popular cache store), because to reset state, we should know exact key names, which is impossible for production considering rack-attack's dynamic key names nature. Unfortunately, memcache does not support deleting based on patterns/prefixes, like in redis. And need to figure out how to use this with custom, created by user, cache stores.
Also, personally, I don't think this is a very popular usecase to reset *production* rack-attack cache. I have used this once to shrink redis memory usage, implemented as a simple rake task executing `scan` and `del` on redis. I think, for general use, changing keys prefix and let the backed store prune old entries here is a valid solution.   

2. Implementation only to support user tests. I implemented this version here. Example of usage:
```ruby
# test_helper.rb
Rack::Attack.test_mode
```

```ruby
# some_test_file.rb
...
setup do
  Rack::Attack.cache.store.clear
end
...
```

After agreeing on implementation, will add missing tests and documentation.