### PR TITLE
Make discriminators case-insensitive by default

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -31,7 +31,7 @@ module Rack
     autoload :Allow2Ban,            'rack/attack/allow2ban'
 
     class << self
-      attr_accessor :enabled, :notifier
+      attr_accessor :enabled, :notifier, :discriminator_normalizer
       attr_reader :configuration
 
       def instrument(request)
@@ -79,6 +79,9 @@ module Rack
     # Set defaults
     @enabled = true
     @notifier = ActiveSupport::Notifications if defined?(ActiveSupport::Notifications)
+    @discriminator_normalizer = lambda do |discriminator|
+      discriminator.to_s.strip.downcase
+    end
     @configuration = Configuration.new
 
     attr_reader :configuration

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -22,8 +22,7 @@ module Rack
       end
 
       def matched_by?(request)
-        discriminator = block.call(request)
-
+        discriminator = discriminator_for(request)
         return false unless discriminator
 
         current_period  = period_for(request)
@@ -48,6 +47,14 @@ module Rack
       end
 
       private
+
+      def discriminator_for(request)
+        discriminator = block.call(request)
+        if discriminator && Rack::Attack.discriminator_normalizer
+          discriminator = Rack::Attack.discriminator_normalizer.call(discriminator)
+        end
+        discriminator
+      end
 
       def period_for(request)
         period.respond_to?(:call) ? period.call(request) : period


### PR DESCRIPTION
Closes #395 

I think, as also mentioned in original issue, discriminators should not only be `downcase`d, but also `strip`ed and `chomp`ed to avoid fooling counters by adding whitespaces.
I'm open for better name to `case_insensitive_discriminator` setting.