### PR TITLE
Speedup CI by running all appraisals in one travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,30 +13,17 @@ before_install:
   - gem update --system
   - gem install bundler -v "~> 2.0"
 
-gemfile:
-  - gemfiles/rack_2_0.gemfile
-  - gemfiles/rack_1_6.gemfile
-  - gemfiles/rails_6_0.gemfile
-  - gemfiles/rails_5_2.gemfile
-  - gemfiles/rails_5_1.gemfile
-  - gemfiles/rails_4_2.gemfile
-  - gemfiles/dalli2.gemfile
-  - gemfiles/redis_4.gemfile
-  - gemfiles/redis_3.gemfile
-  - gemfiles/connection_pool_dalli.gemfile
-  - gemfiles/active_support_redis_cache_store.gemfile
-  - gemfiles/active_support_redis_cache_store_pooled.gemfile
-  - gemfiles/redis_store.gemfile
-  - gemfiles/active_support_redis_store.gemfile
+install:
+  - bundle install --jobs=3 --retry=3
+  - bundle exec appraisal install --jobs=3 --retry=3
+
+script:
+  - bundle exec rubocop
+  - bundle exec appraisal rake
 
 matrix:
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - gemfile: gemfiles/rails_6_0.gemfile
-      rvm: 2.4.9
-    - gemfile: gemfiles/rails_6_0.gemfile
-      rvm: 2.3.8
   fast_finish: true
 
 services:

--- a/Appraisals
+++ b/Appraisals
@@ -17,8 +17,10 @@ appraise "rack_1_6" do
   gem "rack-test", ">= 0.6"
 end
 
-appraise 'rails_6-0' do
-  gem 'railties', '~> 6.0.0'
+if !ENV.key?("CI") || (ENV["CI"] && RUBY_VERSION >= "2.5")
+  appraise 'rails_6-0' do
+    gem 'railties', '~> 6.0.0'
+  end
 end
 
 appraise 'rails_5-2' do


### PR DESCRIPTION
Currently ci is running 1 hour 15 minutes in average. This should *significantly* improve this time. Let's see, if I'm correct.