### PR TITLE
Remove support for ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisabledByDefault: true
   Exclude:
     - "examples/instrumentation.rb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.6.5
   - 2.5.7
   - 2.4.9
-  - 2.3.8
 
 before_install:
   - gem update --system
@@ -35,8 +34,6 @@ matrix:
   exclude:
     - gemfile: gemfiles/rails_6_0.gemfile
       rvm: 2.4.9
-    - gemfile: gemfiles/rails_6_0.gemfile
-      rvm: 2.3.8
   fast_finish: true
 
 services:

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/kickstarter/rack-attack"
   }
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_runtime_dependency 'rack', ">= 1.0", "< 3"
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/