### PR TITLE
Do not rescue all errors for redis backed stores

### DIFF
--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -15,33 +15,17 @@ module Rack
           #
           # So in order to workaround this we use RedisCacheStore#write (which sets expiration) to initialize
           # the counter. After that we continue using the original RedisCacheStore#increment.
-          rescuing do
-            if options[:expires_in] && !read(name)
-              write(name, amount, options)
+          if options[:expires_in] && !read(name)
+            write(name, amount, options)
 
-              amount
-            else
-              super
-            end
+            amount
+          else
+            super
           end
-        end
-
-        def read(*_args)
-          rescuing { super }
         end
 
         def write(name, value, options = {})
-          rescuing do
-            super(name, value, options.merge!(raw: true))
-          end
-        end
-
-        private
-
-        def rescuing
-          yield
-        rescue Redis::BaseError
-          nil
+          super(name, value, options.merge!(raw: true))
         end
       end
     end

--- a/lib/rack/attack/store_proxy/redis_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_proxy.rb
@@ -47,7 +47,7 @@ module Rack
 
         def rescuing
           yield
-        rescue Redis::BaseError
+        rescue Redis::BaseConnectionError
           nil
         end
       end


### PR DESCRIPTION
It is a very bad idea to rescue **all** redis errors (including errors for invalid commands). We can't know when we messed things up in code, because all errors will be silently swallowed. It is better to rescue only connection-related errors. `RedisCacheStore` already rescues connection errors, so no need to do it manually.