### PR TITLE
Fix RedisStoreProxy write when passing expires_in option

### DIFF
--- a/lib/rack/attack/store_proxy/redis_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_store_proxy.rb
@@ -16,7 +16,7 @@ module Rack
 
         def write(key, value, options = {})
           if (expires_in = options[:expires_in])
-            rescuing { setex(key, expires_in, value, raw: true) }
+            rescuing { setex(key, expires_in, value) }
           else
             rescuing { set(key, value, raw: true) }
           end


### PR DESCRIPTION
Version: HEAD
Redis verison: 4.1.3
Rails version: 5.1.7

This happened while throttling requests. While I was using rack-attack 6.0 I was running into exceptions when redis was offline and noticed #445, so I updated rack-attack.  After that, I got a different exception:

```ruby
> wrong number of arguments (given 4, expected 3)

redis (4.1.3) lib/redis.rb, line 819
------------------------------------

  814     #
  815     # @param [String] key
  816     # @param [Fixnum] ttl
  817     # @param [String] value
  818     # @return [String] `"OK"`
> 819     def setex(key, ttl, value)
  820       synchronize do |client|
  821         client.call([:setex, key, ttl, value.to_s])
  822       end
  823     end
  824   

Full backtrace
--------------
 - redis (4.1.3) lib/redis.rb:819:in `setex'
 - /usr/local/lib/ruby/2.5.0/delegate.rb:83:in `method_missing'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/store_proxy/redis_store_proxy.rb:19:in `block in write'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/store_proxy/redis_proxy.rb:62:in `rescuing'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/store_proxy/redis_store_proxy.rb:19:in `write'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/cache.rb:79:in `do_count'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/cache.rb:26:in `count'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/throttle.rb:30:in `matched_by?'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/configuration.rb:77:in `block in throttled?'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/configuration.rb:76:in `any?'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack/configuration.rb:76:in `throttled?'
 -  () usr/local/bundle/bundler/gems/rack-attack-a7ce9a89fe68/lib/rack/attack.rb:108:in `call'
```

Looking at the [docs](https://www.rubydoc.info/github/redis/redis-rb/Redis#setex-instance_method), it doesn't seem possible to pass an `options` arguments there.

I did not add any tests since this there weren't any for `lib/rack/attack/store_proxy/redis_store_proxy.rb` and this seemed pretty specific, so it shouldn't go to the offline examples.

After doing so, rack attack continued working correctly.