### PR TITLE
fix: avoid unintended effects on load_config_initializers and other gems load order

### DIFF
--- a/lib/rack/attack.rb
+++ b/lib/rack/attack.rb
@@ -153,8 +153,9 @@ module Rack
     end
 
     def call(env)
-      return @app.call(env) unless self.class.enabled
+      return @app.call(env) if !self.class.enabled || env["rack.attack.called"]
 
+      env["rack.attack.called"] = true
       env['PATH_INFO'] = PathNormalizer.normalize_path(env['PATH_INFO'])
       request = Rack::Attack::Request.new(env)
 

--- a/lib/rack/attack/railtie.rb
+++ b/lib/rack/attack/railtie.rb
@@ -3,17 +3,9 @@
 module Rack
   class Attack
     class Railtie < ::Rails::Railtie
-      initializer 'rack.attack.middleware', after: :load_config_initializers, before: :build_middleware_stack do |app|
+      initializer "rack-attack.middleware" do |app|
         if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new("5.1")
-          middlewares = app.config.middleware
-          operations = middlewares.send(:operations) + middlewares.send(:delete_operations)
-
-          use_middleware = operations.none? do |operation|
-            middleware = operation[1]
-            middleware.include?(Rack::Attack)
-          end
-
-          middlewares.use(Rack::Attack) if use_middleware
+          app.middleware.use(Rack::Attack)
         end
       end
     end

--- a/spec/acceptance/rails_middleware_spec.rb
+++ b/spec/acceptance/rails_middleware_spec.rb
@@ -18,12 +18,6 @@ if defined?(Rails)
         assert_equal 1, @app.middleware.count(Rack::Attack)
       end
 
-      it "is not added when it was added explicitly" do
-        @app.config.middleware.use(Rack::Attack)
-        @app.initialize!
-        assert_equal 1, @app.middleware.count(Rack::Attack)
-      end
-
       it "is not added when it was explicitly deleted" do
         @app.config.middleware.delete(Rack::Attack)
         @app.initialize!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,8 @@ class MiniTest::Spec
     Rack::Builder.new do
       # Use Rack::Lint to test that rack-attack is complying with the rack spec
       use Rack::Lint
+      # Intentionally added twice to test idempotence property
+      use Rack::Attack
       use Rack::Attack
       use Rack::Lint
 


### PR DESCRIPTION
Because of the sort algorithm rails uses to satisfy `after` and `before`
constraints, gems can have unintended effects on others. See
https://github.com/rails/rails/commit/0a120a818d413c64ff9867125f0b03788fc306f8

Prefer making rack-attack middleware idempotent instead of relying on
the load order and the contents of the middleware stack too much.

closes #452
closes #456