### PR TITLE
Fix deprecation warning in Rails 5.2.4.3

### DIFF
--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -15,7 +15,7 @@ module Rack
           #
           # So in order to workaround this we use RedisCacheStore#write (which sets expiration) to initialize
           # the counter. After that we continue using the original RedisCacheStore#increment.
-          if options[:expires_in] && !read(name)
+          if options[:expires_in] && !read(name, raw: true)
             write(name, amount, options)
 
             amount

--- a/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
+++ b/lib/rack/attack/store_proxy/redis_cache_store_proxy.rb
@@ -15,13 +15,17 @@ module Rack
           #
           # So in order to workaround this we use RedisCacheStore#write (which sets expiration) to initialize
           # the counter. After that we continue using the original RedisCacheStore#increment.
-          if options[:expires_in] && !read(name, raw: true)
+          if options[:expires_in] && !read(name)
             write(name, amount, options)
 
             amount
           else
             super
           end
+        end
+
+        def read(name, options = {})
+          super(name, options.merge!(raw: true))
         end
 
         def write(name, value, options = {})


### PR DESCRIPTION
Rails 5.2.4.3 was released today, with a [security fix](https://github.com/rails/rails/commit/467e3399c9007996c03ffe3212689d48dd25ae99) for [CVE-2020-8165](https://groups.google.com/forum/#!topic/rubyonrails-security/bv6fW4S0Y1c). As a result of this fix, Rack::Attack now throws deprecation warnings, because it writes a value to cache with `raw: true` but reads it back in a subsequent request WITHOUT `raw: true`.