### PR TITLE
Consolidate #testing section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ See the [Backing & Hacking blog post](https://www.kickstarter.com/backing-and-ha
 - [Testing](#testing)
 - [How it works](#how-it-works)
   - [About Tracks](#about-tracks)
-- [Testing](#testing)
 - [Performance](#performance)
 - [Motivation](#motivation)
 - [Contributing](#contributing)
@@ -396,6 +395,10 @@ end
 
 ## Testing
 
+A note on developing and testing apps using Rack::Attack - if you are using throttling in particular, you will
+need to enable the cache in your development environment. See [Caching with Rails](http://guides.rubyonrails.org/caching_with_rails.html)
+for more on how to do this.
+
 ### Disabling
 
 `Rack::Attack.enabled = false` can be used to either completely disable Rack::Attack in your tests, or to disable/enable for specific test cases only.
@@ -440,13 +443,6 @@ can cleanly monkey patch helper methods onto the
 ### About Tracks
 
 `Rack::Attack.track` doesn't affect request processing. Tracks are an easy way to log and measure requests matching arbitrary attributes.
-
-
-## Testing
-
-A note on developing and testing apps using Rack::Attack - if you are using throttling in particular, you will
-need to enable the cache in your development environment. See [Caching with Rails](http://guides.rubyonrails.org/caching_with_rails.html)
-for more on how to do this.
 
 ## Performance
 


### PR DESCRIPTION
The README currently has two sections titled "Testing", with the same anchor (so clicking on the second "Testing" link in the Table of Contents actually links to the first "Testing" section). This PR consolidates the two sections into a single section.