### PR TITLE
Use RuboCop 0.84.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,10 +21,25 @@ Gemspec:
 Layout:
   Enabled: true
 
+Layout/EmptyLinesAroundAttributeAccessor: # (0.83)
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator: # (0.82)
+  Enabled: true
+
 Layout/LineLength:
   Max: 120
 
 Lint:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant: # (0.84)
+  Enabled: true
+
+Lint/RaiseException: # (0.81)
+  Enabled: true
+
+Lint/StructNewOverride: # (0.81)
   Enabled: true
 
 Naming:
@@ -41,9 +56,6 @@ Security:
 Style/BlockDelimiters:
   Enabled: true
   IgnoredMethods: [] # Workaround rubocop bug: https://github.com/rubocop-hq/rubocop/issues/6179
-
-Style/BracesAroundHashParameters:
-  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled: true

--- a/lib/rack/attack/cache.rb
+++ b/lib/rack/attack/cache.rb
@@ -12,6 +12,7 @@ module Rack
       end
 
       attr_reader :store
+
       def store=(store)
         @store =
           if (proxy = BaseProxy.lookup(store))

--- a/lib/rack/attack/check.rb
+++ b/lib/rack/attack/check.rb
@@ -4,6 +4,7 @@ module Rack
   class Attack
     class Check
       attr_reader :name, :block, :type
+
       def initialize(name, options = {}, &block)
         @name = name
         @block = block

--- a/lib/rack/attack/throttle.rb
+++ b/lib/rack/attack/throttle.rb
@@ -6,6 +6,7 @@ module Rack
       MANDATORY_OPTIONS = [:limit, :period].freeze
 
       attr_reader :name, :limit, :period, :block, :type
+
       def initialize(name, options, &block)
         @name = name
         @block = block

--- a/rack-attack.gemspec
+++ b/rack-attack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest-stub-const", "~> 0.6"
   s.add_development_dependency 'rack-test', "~> 1.0"
   s.add_development_dependency 'rake', "~> 13.0"
-  s.add_development_dependency "rubocop", "0.78.0"
+  s.add_development_dependency "rubocop", "0.84.0"
   s.add_development_dependency "rubocop-performance", "~> 1.5.0"
   s.add_development_dependency "timecop", "~> 0.9.1"
 


### PR DESCRIPTION
This PR updates RuboCop to latest release.

  - enable each of the new Cops
  - mark each new Cop with the version they appeared in
  - use RuboCop with `-a` for autofix

[RuboCop 0.84.0 release notes](https://github.com/rubocop-hq/rubocop/releases/tag/v0.84.0)

---

I saw that this repo was using a slightly outdated RuboCop when running the tests for https://github.com/rack/rack/pull/1664 