### PR TITLE
Clarify Calling HTTP_APIKey header in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ E.g.
 # Provided that trusted users use an HTTP request header named APIKey
 Rack::Attack.safelist("mark any authenticated access safe") do |request|
   # Requests are allowed if the return value is truthy
-  request.env["HTTP_APIKey"] == "secret-string"
+  request.env["HTTP_APIKEY"] == "secret-string"
 end
 
 # Always allow requests from localhost

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ E.g.
 # Provided that trusted users use an HTTP request header named APIKey
 Rack::Attack.safelist("mark any authenticated access safe") do |request|
   # Requests are allowed if the return value is truthy
-  request.env["APIKey"] == "secret-string"
+  request.env["HTTP_APIKey"] == "secret-string"
 end
 
 # Always allow requests from localhost


### PR DESCRIPTION
In trying to track down a bug here turns out I was trying to reference the wrong header shown in the readme. 

Printing our `request.env` it becomes clear this is just the full request object:

```
{"rack.version"=>[1, 3],
 "rack.errors"=>#<IO:<STDERR>>,
 "rack.multithread"=>true,
 "rack.multiprocess"=>false,
 "rack.run_once"=>false,
 "SCRIPT_NAME"=>"",
 "QUERY_STRING"=>"",
 "SERVER_PROTOCOL"=>"HTTP/1.1",
 "SERVER_SOFTWARE"=>"puma 4.3.5 Mysterious Traveller",
 "GATEWAY_INTERFACE"=>"CGI/1.2",
 "REQUEST_METHOD"=>"POST",
 "REQUEST_PATH"=>"/api/v1/....",
 "REQUEST_URI"=>"/api/v1/...",
 "HTTP_VERSION"=>"HTTP/1.1",
 "HTTP_HOST"=>"example.com",
 "HTTP_APIKEY"=>"secret_key",
 "CONTENT_TYPE"=>"application/json",
 "HTTP_USER_AGENT"=>"PostmanRuntime/7.25.0",
 "HTTP_ACCEPT"=>"*/*",
 "HTTP_CACHE_CONTROL"=>"no-cache",
...
```